### PR TITLE
Fix panic on clearTimeout inside setTimeout callback

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.3.2) stable; urgency=medium
+
+  * Fix panic on clearTimeout inside setTimeout callback
+
+ -- Roman Kubar <r.kubar@wirenboard.ru>  Tue, 05 May 2020 18:53:48 +0300
+
 wb-rules (2.3.1) stable; urgency=medium
 
   * Fix external controls without readonly flag

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -836,8 +836,10 @@ func (engine *RuleEngine) fireTimer(n TimerId) {
 }
 
 func (engine *RuleEngine) removeTimer(n TimerId) {
-	engine.timers[n].handleRemove()
-	delete(engine.timers, n)
+	if entry, found := engine.timers[n]; found {
+		entry.handleRemove()
+		delete(engine.timers, n)
+	}
 }
 
 func (engine *RuleEngine) StopTimerByName(name string) {


### PR DESCRIPTION
Если пользователь в функции, которая передаётся в таймер для дальнейшего выполнения, удалит таймер, то возникала ситуация, когда движок wb-rules без проверки существования записи в мапе пытается получить доступ к уже удалённому элементу и падал в пануке.