### PR TITLE
properly initialize rules defined in timer callbacks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.6.1) stable; urgency=medium
+
+  * properly initialize rules defined in timer callbacks
+
+ -- Evgeny Boger <boger@contactless.ru>  Tue, 20 Oct 2020 18:21:14 +0300
+
 wb-rules (2.6.0) stable; urgency=medium
 
   * added ability to subscribe to any mqtt-topic with custom handler

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -1586,6 +1586,9 @@ func (engine *RuleEngine) DefineRule(rule *Rule, ctx *ESContext) (id RuleId, err
 		return
 	}
 
+	// needed for rules defined after initial file load, for instance in timers or other rules
+	rule.MaybeAddToCron(engine.cron);
+
 	engine.ruleList = append(engine.ruleList, rule.id)
 
 	engine.ruleMap[rule.id] = rule


### PR DESCRIPTION
клиент проверил https://support.wirenboard.com/t/ne-rabotaet-cron-v-wb-rules-2-6-0/6037/8