### PR TITLE
Alarms schema is updated

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.6.2) stable; urgency=medium
+
+  * alarms schema for wb-mqtt-homeui is updated to allow correct expectedValue property editing
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 27 Jan 2021 11:41:00 +0500
+
 wb-rules (2.6.1) stable; urgency=medium
 
   * properly initialize rules defined in timer callbacks

--- a/rules/alarms.schema.json
+++ b/rules/alarms.schema.json
@@ -211,16 +211,14 @@
     },
     "recipient": {
       "options": {
-        "remove_empty_properties": true
+        "remove_empty_properties": true,
+        "disable_collapse" : true
       },
       "title" : "Recipient",
       "oneOf": [
         { "$ref": "#/definitions/emailRecipient" },
         { "$ref": "#/definitions/smsRecipient" }
-      ],
-      "options": {
-        "disable_collapse" : true
-      }
+      ]
     },
     "alarm": {
       "headerTemplate": "Alarm{{: |self.name}}",
@@ -232,7 +230,7 @@
       ],
       "options": {
         "disable_collapse" : true,
-        "remove_empty_properties": true
+        "remove_empty_properties": false
       }
 
     }


### PR DESCRIPTION
With remove_empty_properties set to true json-editor can't handle expectedValue boolean property with value "false". It removes expectedValue property from resulting JSON instead of setting it to "false".