### PR TITLE
fix dirty stack in RemoveCallback

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules (2.6.3) stable; urgency=high
+
+  * fixed dirty stack in RemoveCallback which led to crashes on garbage
+    collection when many temporary objects were created
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Wed, 24 Feb 2021 16:33:52 +0300
+
 wb-rules (2.6.2) stable; urgency=medium
 
   * alarms schema for wb-mqtt-homeui is updated to allow correct expectedValue property editing

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -104,6 +104,12 @@ func (ctx *ESContext) invalidate() {
 	ctx.valid = false
 }
 
+func (ctx *ESContext) assertStackClean(stack_top int) {
+	if ctx.GetTop() != stack_top {
+		wbgong.Error.Panicf("stack top assertion failed: expected %d, got %d", stack_top, ctx.GetTop())
+	}
+}
+
 func (ctx *ESContext) IsValid() bool {
 	return ctx.valid
 }
@@ -378,10 +384,12 @@ func (ctx *ESContext) removeCallbackSync(key ESCallback) {
 
 func (ctx *ESContext) RemoveCallback(key ESCallback) {
 	ctx.mustBeValid()
+	defer ctx.assertStackClean(ctx.GetTop())
+
 	ctx.PushHeapStash()
 	ctx.GetPropString(-1, ESCALLBACKS_OBJ_NAME)
 	ctx.DelPropString(-1, ctx.callbackKey(key))
-	ctx.Pop()
+	ctx.Pop2()
 }
 
 func (ctx *ESContext) EvalScript(code string) error {

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -383,7 +383,10 @@ func (ctx *ESContext) removeCallbackSync(key ESCallback) {
 }
 
 func (ctx *ESContext) RemoveCallback(key ESCallback) {
-	ctx.mustBeValid()
+	if !ctx.IsValid() {
+		return
+	}
+
 	defer ctx.assertStackClean(ctx.GetTop())
 
 	ctx.PushHeapStash()


### PR DESCRIPTION
В дальнейшем стоило бы просмотреть весь код wb-rules на предмет неаккуратных операций со стеком и расставить такой assert в других местах. Я попробовал, но там слишком много неочевидностей, чтобы срочно тратить на это время.