### PR TITLE
test correct wbgo behavior (bug #29350)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.6.4) stable; urgency=medium
+
+  * fixed control write when empty string is forced default value
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 19 Apr 2021 19:25:09 +0300
+
 wb-rules (2.6.3) stable; urgency=high
 
   * fixed dirty stack in RemoveCallback which led to crashes on garbage

--- a/wbrules/testrules_reload_3.js
+++ b/wbrules/testrules_reload_3.js
@@ -1,0 +1,22 @@
+defineVirtualDevice("testNulledControl", {
+    cells: {
+        pers_text: {
+            type: "text",
+            readonly: false,
+            forceDefault: true,
+            value: ""
+        },
+        trigger: {
+            type: "pushbutton"
+        }
+    }
+});
+
+defineRule({
+    whenChanged: "testNulledControl/trigger", 
+    then: function() {
+        log.info("before: {}".format(dev["testNulledControl"]["pers_text"]))
+        dev["testNulledControl"]["pers_text"] = "someTextString"
+        log.info("after: {}".format(dev["testNulledControl"]["pers_text"]))
+    }
+});

--- a/wbrules/testrules_reload_3_changed.js
+++ b/wbrules/testrules_reload_3_changed.js
@@ -1,0 +1,25 @@
+// the same code as in testrules_reload_3.js,
+// but it should cause script reloading
+
+defineVirtualDevice("testNulledControl", {
+    cells: {
+        pers_text: {
+            type: "text",
+            readonly: false,
+            forceDefault: true,
+            value: ""
+        },
+        trigger: {
+            type: "pushbutton"
+        }
+    }
+});
+
+defineRule({
+    whenChanged: "testNulledControl/trigger", 
+    then: function() {
+        log.info("before: {}".format(dev["testNulledControl"]["pers_text"]))
+        dev["testNulledControl"]["pers_text"] = "someTextString"
+        log.info("after: {}".format(dev["testNulledControl"]["pers_text"]))
+    }
+});;


### PR DESCRIPTION
Код самого wb-rules не меняется (вообще стоило бы, но чтобы получилось нормально, нужна ну очень масштабная переделка, не думаю, что это сейчас нужно). Здесь только тест, который воспроизводит багу, чинится обновлением wbgo в PR #17.

P.S. Тот неловкий момент, когда год назад эту багу почти исправили: #38 