### PR TITLE
Quotes in SystemD `Environment`

### DIFF
--- a/debian/wb-rules.service
+++ b/debian/wb-rules.service
@@ -9,7 +9,7 @@ Type=simple
 Restart=on-failure
 RestartSec=1
 User=root
-Environment=WB_RULES_MODULES="/etc/wb-rules-modules:/usr/share/wb-rules-modules"
+Environment="WB_RULES_MODULES=/etc/wb-rules-modules:/usr/share/wb-rules-modules"
 ExecStart=/usr/bin/wb-rules -syslog -editdir '/etc/wb-rules/' '/usr/share/wb-rules-system/rules/' '/etc/wb-rules/' '/usr/share/wb-rules/'
 
 [Install]


### PR DESCRIPTION
https://github.com/wirenboard/wb-rules/blob/46fdad13213f24ccd83fbf8290c888826bc27652/debian/wb-rules.service#L12

Не сразу понял почему перестали загружаться модули через `require()`. Если брать в кавычки только значение, то в скрипт оно передается тоже с кавычками:
![image](https://user-images.githubusercontent.com/3369328/120825427-0c5fbd80-c562-11eb-8cc1-6315eea77b54.png)
Похоже, в этот момент загрузчик модулей не понимает как обработать такие пути и не подгружает модули.

Как [советуют на SO](https://askubuntu.com/a/614120/307409) и ссылаются на [доку SystemD](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines), надо брать в кавычки все выражение, например:
```
Environment="WB_RULES_MODULES=/etc/wb-rules-modules:/usr/share/wb-rules-modules" 
```
Либо обойтись совсем без кавычек. В обоих случаях пути в переменной окружения передаются нормально и загрузка модулей происходит без ошибок:
![image](https://user-images.githubusercontent.com/3369328/120824681-585e3280-c561-11eb-98f8-b507732f8675.png)