### PR TITLE
wbgo: fix crashes in support.go file (up version)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.11.2) stable; urgency=medium
+
+  * wbgo: fix crashes in support.go file
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 31 Mar 2022 15:17:46 +0300
+
 wb-rules (2.11.1) stable; urgency=medium
 
   * Updated documentation


### PR DESCRIPTION
depends on https://github.com/wirenboard/wbgo-private/pull/26