### PR TITLE
fix rare 'nil pointer dereference' panics around cron rules

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.11.4) stable; urgency=medium
+
+  * Fix rare "nil pointer dereference" panics around cron rules
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 28 Jun 2022 02:03:15 +0300
+
 wb-rules (2.11.3) stable; urgency=medium
 
   * An error causing system reboot is fixed

--- a/wbrules/rule.go
+++ b/wbrules/rule.go
@@ -321,7 +321,9 @@ func (rule *Rule) Check(e *ControlChangeEvent) {
 func (rule *Rule) MaybeAddToCron(cron Cron) {
 	var err error
 	rule.isIndependent, err = rule.cond.MaybeAddToCron(cron, func() {
-		rule.then(nil)
+		if rule.then != nil {
+			rule.then(nil)
+		}
 	})
 	if err != nil {
 		wbgong.Error.Printf("rule %s: invalid cron spec: %s", rule.name, err)


### PR DESCRIPTION
https://support.wirenboard.com/t/wb-rules-segmentation-violation/11746

Иногда при замене/удалении файла с cron-правилами может возникнуть ошибка nil pointer dereference. Подозреваю, что есть гонка при исключении правила из cron.