### PR TITLE
add mosquitto socket support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.14.0) stable; urgency=medium
+
+  * add mosquitto UNIX socket connection by default (if it is detected)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 17 Aug 2022 10:55:31 +0300
+
 wb-rules (2.13.0) stable; urgency=medium
 
   * Added support for title field in controls

--- a/debian/wb-rules.service
+++ b/debian/wb-rules.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=MQTT Rule engine for Wiren Board
-Requires=mosquitto.service
 Wants=wb-hwconf-manager.service wb-modules.service
 After=wb-hwconf-manager.service wb-modules.service mosquitto.service
 


### PR DESCRIPTION
Нужно для совместимости с bullseye, где используется mosquitto 2.0.11 с подключением через UNIX-сокет.