### PR TITLE
Feature/47544 incorrect handling of the extra brace in scripts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules (2.16.0) stable; urgency=medium
+
+  * Fixed behavior that occurred when adding an extra closing curly brace to a script
+  * Fixed a bug that occurred if there was no line break after a comment in the last line
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Thu, 01 Sep 2022 15:19:16 +0400
+
 wb-rules (2.15.0) stable; urgency=medium
 
   * Added support for units when declaring a virtual device

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -3,6 +3,7 @@ package wbrules
 import (
 	"bytes"
 	"fmt"
+	"github.com/wirenboard/wb-rules/wbrules/util"
 	"io/ioutil"
 	"log"
 	"reflect"
@@ -424,8 +425,10 @@ func (ctx *ESContext) LoadScenario(path string) error {
 		return err
 	}
 
-	// wrap source code
-	src := "function(module){" + string(srcRaw) + "}"
+	err, src := util.WrapWbScriptToJSFunction(string(srcRaw))
+	if err != nil {
+		return err
+	}
 
 	// compile function
 	if err = ctx.LoadFunctionFromString(path, src); err != nil {
@@ -437,7 +440,7 @@ func (ctx *ESContext) LoadScenario(path string) error {
 
 	// set module prototype
 	ctx.PushGlobalObject()
-	ctx.GetPropString(-1, "__wbModulePrototype")
+	ctx.GetPropString(-1, MODULE_OBJ_PROTO_NAME)
 	ctx.SetPrototype(-3)
 	ctx.Pop()
 

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -3,6 +3,7 @@ package wbrules
 import (
 	"bytes"
 	"fmt"
+	. "github.com/wirenboard/wb-rules/wbrules/eserror"
 	"github.com/wirenboard/wb-rules/wbrules/util"
 	"io/ioutil"
 	"log"
@@ -22,12 +23,6 @@ const (
 	FILENAME_PROP_NAME   = "__filename"
 )
 
-type ESLocation struct {
-	filename string
-	line     int
-}
-
-type ESTraceback []ESLocation
 type ESCallback uint64
 type ESCallbackFunc func(args objx.Map) interface{}
 type ESCallbackErrorHandler func(err ESError)
@@ -47,11 +42,6 @@ type ESContext struct {
 	valid bool
 }
 
-type ESError struct {
-	Message   string
-	Traceback ESTraceback
-}
-
 // ESContextFactory creates ESContexts and  stores properties which are
 // common for related ESContexts (in one application).
 // ESContextFactory is logically binded to Duktape heap.
@@ -65,10 +55,6 @@ func newESContextFactory() *ESContextFactory {
 		duktapeToESContextMap: make(map[duktape.Context]*ESContext),
 		callbackIndex:         1,
 	}
-}
-
-func (err ESError) Error() string {
-	return err.Message
 }
 
 func (f *ESContextFactory) newESContext(syncFunc ESSyncFunc, filename string) *ESContext {
@@ -427,13 +413,7 @@ func (ctx *ESContext) LoadScenario(path string) error {
 
 	err, src := util.WrapWbScriptToJSFunction(string(srcRaw))
 	if err != nil {
-		r := ESError{
-			err.Error(),
-			ESTraceback{
-				{filename: path, line: 0},
-			},
-		}
-		return r
+		return err
 	}
 
 	// compile function
@@ -586,7 +566,7 @@ func (ctx *ESContext) GetESErrorAugmentingSyntaxErrors(path string) (r ESError) 
 	r = ESError{
 		r.Message,
 		ESTraceback{
-			{filename: path, line: lineNumber},
+			{Filename: path, Line: lineNumber},
 		},
 	}
 	return

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -413,7 +413,9 @@ func (ctx *ESContext) LoadScenario(path string) error {
 
 	err, src := util.WrapWbScriptToJSFunction(string(srcRaw))
 	if err != nil {
-		return err
+		eserr := err.(ESError)
+		eserr.Traceback[0].Filename = path
+		return eserr
 	}
 
 	// compile function

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -427,7 +427,13 @@ func (ctx *ESContext) LoadScenario(path string) error {
 
 	err, src := util.WrapWbScriptToJSFunction(string(srcRaw))
 	if err != nil {
-		return err
+		r := ESError{
+			err.Error(),
+			ESTraceback{
+				{filename: path, line: 0},
+			},
+		}
+		return r
 	}
 
 	// compile function

--- a/wbrules/escontext_test.go
+++ b/wbrules/escontext_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
+	. "github.com/wirenboard/wb-rules/wbrules/eserror"
 )
 
 var objTests = []string{

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/stretchr/objx"
 	duktape "github.com/wirenboard/go-duktape"
+	. "github.com/wirenboard/wb-rules/wbrules/eserror"
 	"github.com/wirenboard/wbgong"
 )
 
@@ -589,8 +590,8 @@ func (engine *ESEngine) registerSourceItem(ctx *ESContext, typ itemType, name st
 	for _, loc := range ctx.GetTraceback() {
 		// Here we depend upon the fact that duktape displays
 		// unmodified source paths in the backtrace
-		if loc.filename == currentPath {
-			line = loc.line
+		if loc.Filename == currentPath {
+			line = loc.Line
 		}
 	}
 	if line == -1 {
@@ -807,9 +808,9 @@ func (engine *ESEngine) trackESError(path string, err error) error {
 	traceback := make([]LocItem, 0, len(esError.Traceback))
 	for _, esLoc := range esError.Traceback {
 		_, virtualPath, underSourceRoot, _, err :=
-			engine.checkSourcePath(esLoc.filename)
+			engine.checkSourcePath(esLoc.Filename)
 		if err == nil && underSourceRoot {
-			traceback = append(traceback, LocItem{esLoc.line, virtualPath})
+			traceback = append(traceback, LocItem{esLoc.Line, virtualPath})
 		}
 	}
 

--- a/wbrules/eserror/error.go
+++ b/wbrules/eserror/error.go
@@ -1,0 +1,17 @@
+package eserror
+
+type ESError struct {
+	Message   string
+	Traceback ESTraceback
+}
+
+func (err ESError) Error() string {
+	return err.Message
+}
+
+type ESLocation struct {
+	Filename string
+	Line     int
+}
+
+type ESTraceback []ESLocation

--- a/wbrules/util/common.go
+++ b/wbrules/util/common.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"fmt"
+)
+
+type ContextType int
+
+const (
+	Code ContextType = iota
+	SingleQuotes
+	DoubleQuotes
+	SingleLineComment
+	MiltiLineComment
+)
+
+func CheckWbScript(src string) error {
+	var prevCh int32 = ' '
+	var braceCounter int = 0
+	var row int = 1
+	var col int = 0
+	var contextType = Code
+
+	var printRowCol = func() string {
+		return fmt.Sprintf("(%d:%d)", row, col)
+	}
+
+	for _, ch := range src {
+		col++
+		switch ch {
+		case '{':
+			if contextType == Code {
+				braceCounter++
+			}
+		case '}':
+			if contextType == Code {
+				braceCounter--
+			}
+		case '\n':
+			row++
+			prevCh = ' '
+			switch contextType {
+			case SingleLineComment:
+				contextType = Code
+			case SingleQuotes:
+				fallthrough
+			case DoubleQuotes:
+				if prevCh != '\\' {
+					return fmt.Errorf("String format error")
+				}
+			}
+			col = 0
+		case '/':
+			if prevCh == '/' && contextType == Code {
+				contextType = SingleLineComment
+			} else if prevCh == '*' && contextType == MiltiLineComment {
+				contextType = Code
+			}
+		case '*':
+			if contextType == Code && prevCh == '/' {
+				contextType = MiltiLineComment
+			}
+		case '"':
+			switch contextType {
+			case Code:
+				contextType = DoubleQuotes
+			case DoubleQuotes:
+				contextType = Code
+			}
+		case '\'':
+			switch contextType {
+			case Code:
+				contextType = SingleQuotes
+			case SingleQuotes:
+				contextType = Code
+			}
+		}
+		if braceCounter < 0 {
+			return fmt.Errorf("%s Missing opening bracket", printRowCol())
+		}
+		prevCh = ch
+	}
+	if braceCounter > 0 {
+		return fmt.Errorf("Missing closed bracket")
+	}
+	if contextType == MiltiLineComment {
+		return fmt.Errorf("Multiline comment is not closed")
+	}
+	if contextType == SingleQuotes || contextType == DoubleQuotes {
+		return fmt.Errorf("String is not closed")
+	}
+	return nil
+}
+
+func WrapWbScriptToJSFunction(src string) (error, string) {
+	if err := CheckWbScript(src); err != nil {
+		return err, ""
+	}
+	result := "function(module){" + src + "\n}"
+	return nil, result
+}

--- a/wbrules/util/common.go
+++ b/wbrules/util/common.go
@@ -33,6 +33,18 @@ func CheckWbScript(src string) error {
 		return err
 	}
 
+	var quotesStringSwitcher = func(ctTarget ContextType, ct ContextType) ContextType {
+		switch ct {
+		case Code:
+			return ctTarget
+		case ctTarget:
+			if prevCh != '\\' {
+				return Code
+			}
+		}
+		return ct
+	}
+
 	for _, ch := range src {
 		col++
 		switch ch {
@@ -69,26 +81,11 @@ func CheckWbScript(src string) error {
 				contextType = MiltiLineComment
 			}
 		case '"':
-			switch contextType {
-			case Code:
-				contextType = DoubleQuotesString
-			case DoubleQuotesString:
-				contextType = Code
-			}
+			contextType = quotesStringSwitcher(DoubleQuotesString, contextType)
 		case '\'':
-			switch contextType {
-			case Code:
-				contextType = SingleQuotesString
-			case SingleQuotesString:
-				contextType = Code
-			}
+			contextType = quotesStringSwitcher(SingleQuotesString, contextType)
 		case '`':
-			switch contextType {
-			case Code:
-				contextType = TemplateString
-			case TemplateString:
-				contextType = Code
-			}
+			contextType = quotesStringSwitcher(TemplateString, contextType)
 		}
 		if braceCounter < 0 {
 			return createEsError(fmt.Sprintf("Missing opening bracket"))

--- a/wbrules/util/common.go
+++ b/wbrules/util/common.go
@@ -23,13 +23,9 @@ func CheckWbScript(src string) error {
 	var col int = 0
 	var contextType = Code
 
-	var printCursorPosition = func() string {
-		return fmt.Sprintf("(%d:%d)", row, col)
-	}
-
 	var createEsError = func(errorStr string) eserror.ESError {
 		err := eserror.ESError{
-			errorStr,
+			errorStr + fmt.Sprintf(" (line: %d column: %d)", row, col),
 			eserror.ESTraceback{
 				{Filename: "", Line: row},
 			},
@@ -49,7 +45,6 @@ func CheckWbScript(src string) error {
 				braceCounter--
 			}
 		case '\n':
-			row++
 			prevCh = ' '
 			switch contextType {
 			case SingleLineComment:
@@ -58,9 +53,10 @@ func CheckWbScript(src string) error {
 				fallthrough
 			case DoubleQuotesString:
 				if prevCh != '\\' {
-					return createEsError(fmt.Sprintf("%s String format error", printCursorPosition()))
+					return createEsError(fmt.Sprintf("String format error"))
 				}
 			}
+			row++
 			col = 0
 		case '/':
 			if prevCh == '/' && contextType == Code {
@@ -95,7 +91,7 @@ func CheckWbScript(src string) error {
 			}
 		}
 		if braceCounter < 0 {
-			return createEsError(fmt.Sprintf("%s Missing opening bracket", printCursorPosition()))
+			return createEsError(fmt.Sprintf("Missing opening bracket"))
 		}
 		prevCh = ch
 	}

--- a/wbrules/util/common_test.go
+++ b/wbrules/util/common_test.go
@@ -1,0 +1,44 @@
+package util
+
+import "testing"
+
+func TestCheckWbScriptCorrectSamples(t *testing.T) {
+	var correctSamples = []string{
+		"",
+		"{{{{{{}}}}}}",
+		`
+{{"{}1' + 2}{"
+/* { "" ' 
+*/
+//}}
+}}
+		`,
+		"{{1 + 2 \n // \n}\n/* jnjknkjn \n*/}",
+	}
+	for num, sample := range correctSamples {
+		if err := CheckWbScript(sample); err != nil {
+			t.Errorf("Function result is false for correct samples. SampleNumber=%d, Error=%s", num+1, err.Error())
+		}
+	}
+}
+
+func TestCheckWbScriptIncorrectSamples(t *testing.T) {
+	var incorrectSamples = []string{
+		"}",
+		"{{{{{{}}}}",
+		"{{1 + 2 \n//}}\n}//}",
+		"{{1 + 2 \n // \n}\n/* jnjknkjn \n*/",
+	}
+	for num, sample := range incorrectSamples {
+		if err := CheckWbScript(sample); err == nil {
+			t.Errorf("Function result is true for incorrect samples. SampleNumber=%d", num+1)
+		}
+	}
+}
+
+func TestWrapWbScriptToJSFunction(t *testing.T) {
+	const src = "1 + 2"
+	if _, result := WrapWbScriptToJSFunction(src); result != "function(module){1 + 2\n}" {
+		t.Errorf("Invalid conversion")
+	}
+}


### PR DESCRIPTION
Исправил поведение при обработке скрипта правил, когда лишняя закрывающая фигурная приводила к экранированию кода, следующего за ней.
Исправил возникающую ошибку, когда на последней строки в скрипте правил после комментария не было перевода строки.