### PR TITLE
Feature/47544 incorrect handling of the extra brace in scripts V2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules (2.16.0) stable; urgency=medium
+
+  * Fixed behavior that occurred when adding an extra closing curly brace to a script
+  * Fixed a bug that occurred if there was no line break after a comment in the last line
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Wed, 07 Sep 2022 19:52:58 +0400
+
 wb-rules (2.15.0) stable; urgency=medium
 
   * Added support for units when declaring a virtual device

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -429,7 +429,7 @@ func (ctx *ESContext) LoadScenario(path string) error {
 
 	// Source code evaluation.
 	// Checking if there are extra curly braces
-	if err := ctx.PcompileString(0, src); err != 0 {
+	if err := ctx.PcompileString(duktape.DUK_COMPILE_EVAL, src); err != 0 {
 		defer ctx.Pop()
 		return ctx.GetESErrorAugmentingSyntaxErrors(path)
 	}

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -425,7 +425,15 @@ func (ctx *ESContext) LoadScenario(path string) error {
 	}
 
 	// wrap source code
-	src := "function(module){" + string(srcRaw) + "}"
+	src := "function F(module){" + string(srcRaw) + "\n}"
+
+	// Source code evaluation.
+	// Checking if there are extra curly braces
+	if err := ctx.PevalString(src); err != 0 {
+		defer ctx.Pop()
+		return ctx.GetESErrorAugmentingSyntaxErrors(path)
+	}
+	ctx.Pop()
 
 	// compile function
 	if err = ctx.LoadFunctionFromString(path, src); err != nil {

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -429,7 +429,7 @@ func (ctx *ESContext) LoadScenario(path string) error {
 
 	// Source code evaluation.
 	// Checking if there are extra curly braces
-	if err := ctx.PevalString(src); err != 0 {
+	if err := ctx.PcompileString(0, src); err != 0 {
 		defer ctx.Pop()
 		return ctx.GetESErrorAugmentingSyntaxErrors(path)
 	}

--- a/wbrules/escontext_test.go
+++ b/wbrules/escontext_test.go
@@ -146,3 +146,22 @@ func TestCallLocation(t *testing.T) {
 		assert.Equal(t, loc.tracebacks, storedTracebacks)
 	}
 }
+
+func TestLoadScenario(t *testing.T) {
+	f := newESContextFactory()
+	ctx := f.newESContext(nil, "")
+	err := ctx.LoadScenario("testrules_load_scenario.js")
+	assert.Equal(t, err, nil)
+}
+
+func TestLoadScenarioNeg(t *testing.T) {
+	f := newESContextFactory()
+	ctx := f.newESContext(nil, "")
+	err := ctx.LoadScenario("testrules_load_scenario_bad.js")
+	if assert.NotEqual(t, err, nil) {
+		eserror, ok := err.(ESError)
+		if assert.Equal(t, true, ok) && assert.NotZero(t, len(eserror.Traceback)) {
+			assert.Equal(t, 5, eserror.Traceback[0].line)
+		}
+	}
+}

--- a/wbrules/testrules_load_scenario.js
+++ b/wbrules/testrules_load_scenario.js
@@ -1,0 +1,4 @@
+
+var x = 2 + 3
+var y = "abcd"
+//last comment

--- a/wbrules/testrules_load_scenario_bad.js
+++ b/wbrules/testrules_load_scenario_bad.js
@@ -1,0 +1,4 @@
+
+var x = 2 + 3
+}
+var y = "aaaa"


### PR DESCRIPTION
Исправил поведение при обработке скрипта правил, когда лишняя закрывающая фигурная приводила к экранированию кода, следующего за ней.
Исправил возникающую ошибку, когда на последней строки в скрипте правил после комментария не было перевода строки.