### PR TITLE
Add warnings about unknown spawn() options

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.17.2) stable; urgency=medium
+
+  * Add warnings about unknown spawn() options
+
+ -- Nikolay Korotki <nikolay.korotkiy@wirenboard.com>  Tue, 22 Nov 2022 02:13:00 +0400
+
 wb-rules (2.17.1) stable; urgency=medium
 
   * Add an error message on SetValue for an unexisting control

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -317,6 +317,14 @@ function spawn(cmd, args, options) {
       options.captureOutput = false;
     if (!options.hasOwnProperty("captureErrorOutput"))
       options.captureErrorOutput = false;
+
+    var keys = Object.keys(options);
+    var knownOptions = ["captureOutput", "captureErrorOutput", "input", "exitCallback"];
+    for (var i = 0; i < keys.length; i++) {
+      if (knownOptions.indexOf(keys[i]) < 0) {
+        log.warning("spawn: unknown option: " + keys[i]);
+      }
+    }
   }
 
   if (options.input != null)


### PR DESCRIPTION
Script example:
```js
  runShellCommand('...', {
    capturedOutput: true, // <- typo! should be "captureOutput"
    exitCallback: function (exitCode, capturedOutput) {
      ...
    }
  });
```
Log example:
```
wb-rules[22092]: WARNING: [rule warning] spawn: unknown option: capturedOutput
```