### PR TITLE
Notify: send SMS via ModemManager if possible + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,6 +1080,8 @@ var myModule = require("path/to/myModule");
 `Notify.sendSMS(to, text, command)` отправляет SMS на указанный номер (`to`)
 с указанным содержимым (`text`), используя команду (`command`) (необязательный аргумент).
 
+Для отправки SMS используется ModemManager, а если он не установлен, то `gammu`.
+
 ## Сервис алармов
 
 Основная функция:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.18.0) stable; urgency=medium
+
+  * Send SMS via ModemManager if it is available
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 17 Jan 2023 16:29:04 +0600
+
 wb-rules (2.17.3) stable; urgency=medium
 
   * Fix alerts schemas issue with email/sms recipient type switching

--- a/wbrules/rule_notify_sms_test.go
+++ b/wbrules/rule_notify_sms_test.go
@@ -1,0 +1,76 @@
+package wbrules
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/wirenboard/wbgong/testutils"
+)
+
+type RuleNotifySmsSuite struct {
+	RuleSuiteBase
+}
+
+func (s *RuleNotifySmsSuite) SetupTest() {
+	s.SetupSkippingDefs("testrules_sms_commands.js")
+}
+
+func (s *RuleNotifySmsSuite) setErrorCode(seqNum, errorCode int) {
+	s.publish(fmt.Sprintf("/devices/test_sms/controls/exit_code_%d/on", seqNum), strconv.Itoa(errorCode),
+		fmt.Sprintf("test_sms/exit_code_%d", seqNum))
+	s.VerifyUnordered(
+		fmt.Sprintf("tst -> /devices/test_sms/controls/exit_code_%d/on: [%d] (QoS 1)", seqNum, errorCode),
+		fmt.Sprintf("driver -> /devices/test_sms/controls/exit_code_%d: [%d] (QoS 1, retained)", seqNum, errorCode),
+	)
+}
+
+func (s *RuleNotifySmsSuite) TestSmsGammu() {
+	s.setErrorCode(1, 1) // to make mmcli check OK
+	s.setErrorCode(2, 0) // to make gammu happy
+
+	s.publish("/devices/test_sms/controls/send/on", "1", "test_sms/send")
+	s.VerifyUnordered(
+		"driver -> /devices/test_sms/controls/send: [1] (QoS 1)",
+		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: mmcli --version] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending sms (gammu-like) to 88005553535: test value] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm restart_if_broken && gammu sendsms TEXT '88005553535' -unicode] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: test value] (QoS 1)",
+	)
+}
+
+func (s *RuleNotifySmsSuite) TestSmsModemManager() {
+	s.setErrorCode(1, 0) // to make mmcli check OK
+	s.setErrorCode(2, 0) // to make mmcli call happy
+
+	s.publish("/devices/test_sms/controls/send/on", "1", "test_sms/send")
+	s.VerifyUnordered(
+		"driver -> /devices/test_sms/controls/send: [1] (QoS 1)",
+		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: mmcli --version] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager) to 88005553535: test value] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test value\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",
+	)
+}
+
+func (s *RuleNotifySmsSuite) TestSmsModemManagerWithQuotes() {
+	s.setErrorCode(1, 0) // to make mmcli check OK
+	s.setErrorCode(2, 0) // to make mmcli call happy
+
+	s.publish("/devices/test_sms/controls/send_quoted/on", "1", "test_sms/send_quoted")
+	s.VerifyUnordered(
+		"driver -> /devices/test_sms/controls/send_quoted: [1] (QoS 1)",
+		"tst -> /devices/test_sms/controls/send_quoted/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: mmcli --version] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager) to 88005553535: test \"value\" 'single'] (QoS 1)",
+		"wbrules-log -> /wbrules/log/warning: [ModemManager can't handle SMS with double quotes now, auto replaced with single ones] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test 'value' 'single'\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",
+	)
+}
+
+func TestNotifySmsSuite(t *testing.T) {
+	testutils.RunSuites(t,
+		new(RuleNotifySmsSuite),
+	)
+}

--- a/wbrules/testrules_sms_commands.js
+++ b/wbrules/testrules_sms_commands.js
@@ -1,0 +1,52 @@
+var exitCodes = []
+
+global.__proto__.runShellCommand = function(command, options) {
+    if (exitCodes.length == 0) {
+        exitCodes = [dev["test_sms/exit_code_2"], dev["test_sms/exit_code_1"]];
+    }
+
+    log("run command: {}", command);
+    if (options.input) {
+        log("input: {}", options.input);
+    }
+    if (options.exitCallback) {
+        options.exitCallback(exitCodes.pop(), "stdout", "stderr");
+    }
+};
+
+defineVirtualDevice("test_sms", {
+    cells: {
+        exit_code_1: {
+            type: "value",
+            readonly: false,
+            value: 0
+        },
+        exit_code_2: {
+            type: "value",
+            readonly: false,
+            value: 0
+        },
+        send: {
+            type: "pushbutton"
+        },
+        send_quoted: {
+            type: "pushbutton"
+        }
+    }
+});
+
+defineRule({
+    whenChanged: "test_sms/send",
+    then: function() {
+        Notify.sendSMS("88005553535", "test value");
+    }
+});
+
+defineRule({
+    whenChanged: "test_sms/send_quoted",
+    then: function() {
+        // can't send messages with all types of quotes via mmcli,
+        // see https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/275
+        Notify.sendSMS("88005553535", "test \"value\" 'single'");
+    }
+});


### PR DESCRIPTION
Пользователи в чате жаловались, что с переходом на NetworkManager сломалась отправка SMS через `Notify` (этим кто-то пользуется, да), потому что там используется `gammu` в качестве команды на отправку.

Добавил возможность отправлять через ModemManager, если он есть, заодно написал тестов.