### PR TITLE
make wb-rules less noisy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-rules (2.18.1) stable; urgency=medium
+
+  * esengine: print "file is NOT under source root" messages in debug
+  * esengine: add parameters for readConfig to suppress errors
+    when file does not exist and it's OK
+
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 30 Jan 2023 15:26:03 +0600
+
 wb-rules (2.18.0) stable; urgency=medium
 
   * Send SMS via ModemManager if it is available


### PR DESCRIPTION
 * esengine: print "file is NOT under source root" messages in debug
 * esengine: add parameters for readConfig to suppress errors when file does not exist and it's OK