### PR TITLE
Fix alarm schema

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,14 @@
+wb-rules (2.18.2) stable; urgency=medium
+
+  * Fix alarm.schema.json
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 26 May 2023 13:32:00 +0400
+
 wb-rules (2.18.1) stable; urgency=medium
 
   * esengine: print "file is NOT under source root" messages in debug
   * esengine: add parameters for readConfig to suppress errors
     when file does not exist and it's OK
-
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 30 Jan 2023 15:26:03 +0600
 
@@ -23,7 +28,7 @@ wb-rules (2.17.2) stable; urgency=medium
 
   * Add warnings about unknown spawn() options
 
- -- Nikolay Korotki <nikolay.korotkiy@wirenboard.com>  Tue, 22 Nov 2022 02:13:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 22 Nov 2022 02:13:00 +0400
 
 wb-rules (2.17.1) stable; urgency=medium
 

--- a/rules/alarms.schema.json
+++ b/rules/alarms.schema.json
@@ -272,7 +272,8 @@
             ],
             "options": {
                 "disable_collapse": true,
-                "remove_empty_properties": false
+                "remove_empty_properties": false,
+                "keep_oneof_values": false
             }
         }
     },


### PR DESCRIPTION
Fix error in config editor when switching between alarm types:
<img width="660" alt="Näyttökuva 2023-5-26 kello 13 37 33" src="https://github.com/wirenboard/wb-rules/assets/688044/12dce760-332f-4996-ad69-f8c7b52a5ed3">
<img width="549" alt="Näyttökuva 2023-5-26 kello 13 39 31" src="https://github.com/wirenboard/wb-rules/assets/688044/2d7798d4-a590-47f8-adb4-8f85039d81f3">
