### PR TITLE
Add homepage to deb package info

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.18.4) stable; urgency=medium
+
+  * Add homepage to deb package info. No functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 25 Jul 2023 16:34:00 +0400
+
 wb-rules (2.18.3) stable; urgency=medium
 
   * Format source code. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Priority: optional
 Multi-Arch: foreign
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9), pkg-config, golang-go:native
+Homepage: https://github.com/wirenboard/wb-rules
 
 Package: wb-rules
 Architecture: any


### PR DESCRIPTION
`wbci-changelog` uses `Homepage` from `deb/control`.