### PR TITLE
Replace warning to debug log level of uncomplete control message

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.18.5) stable; urgency=medium
+
+  * Replace warning to debug log level of uncomplete control message
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Mon, 31 Jul 2023 10:31:52 +0300
+
 wb-rules (2.18.4) stable; urgency=medium
 
   * Add homepage to deb package info. No functional changes

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -836,7 +836,7 @@ func (engine *RuleEngine) driverEventHandler(event wbgong.DriverEvent) {
 
 		value, err = ctrl.GetValue()
 		if err != nil {
-			wbgong.Warn.Printf("%s: failed to convert value '%s', passing raw, error: %s",
+			wbgong.Debug.Printf("%s: failed to convert value '%s', passing raw, error: %s",
 				spec.String(), ctrl.GetRawValue(), err.Error())
 			value = ctrl.GetRawValue()
 		}


### PR DESCRIPTION
От того, что rules не умеет парсить мета как json а не из подтопиков, постоянно сыплются ошибки, так как он думает что нет меты. Так как код rules старый и не очень хороший, решили это не чинить и перевести сообщение ошибки в дебаг