### PR TITLE
fix timer error message after deferred alarm returns back to normal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.18.8) stable; urgency=medium
+
+  * Fix timer error message after deferred alarm returns back to normal
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 20 Dec 2023 17:31:38 +0600
+
 wb-rules (2.18.7) stable; urgency=medium
 
   * Bump golang.org/x/sys, no functional changes

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -646,7 +646,10 @@ var Alarms = (function () {
 
             if (!wasActive) {
               if (alarmSrc.alarmDelayMs > 0)
-                activateTimerId = setTimeout(activateAlarm, alarmSrc.alarmDelayMs);
+                activateTimerId = setTimeout(function() {
+                  activateTimerId = null;
+                  activateAlarm();
+                }, alarmSrc.alarmDelayMs);
               else activateAlarm();
             }
 
@@ -679,7 +682,10 @@ var Alarms = (function () {
 
             if (wasActive) {
               if (alarmSrc.noAlarmDelayMs > 0) {
-                deactivateTimerId = setTimeout(deactivateAlarm, alarmSrc.noAlarmDelayMs);
+                deactivateTimerId = setTimeout(function() {
+                  deactivateTimerId = null;
+                  deactivateAlarm();
+                }, alarmSrc.noAlarmDelayMs);
               } else deactivateAlarm();
             }
 


### PR DESCRIPTION
Если добавить в alarms.conf какой-нибудь alarm с ненулевым activation delay и подёргать его, в логах wb-rules появляются ошибки вроде таких:

```
Dec 20 11:20:53 wirenboard-AMY5ZSMV wb-rules[23107]: ERROR: trying to stop unknown timer: 7
Dec 20 11:20:55 wirenboard-AMY5ZSMV wb-rules[23107]: ERROR: trying to stop unknown timer: 8
Dec 20 11:20:58 wirenboard-AMY5ZSMV wb-rules[23107]: ERROR: trying to stop unknown timer: 9
Dec 20 11:21:03 wirenboard-AMY5ZSMV wb-rules[23107]: ERROR: trying to stop unknown timer: 10
Dec 20 11:21:22 wirenboard-AMY5ZSMV wb-rules[23107]: ERROR: trying to stop unknown timer: 11
```

В этом PR исправляю, ошибка довольно банальная