### PR TITLE
Remove restriction on rule file name

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.20.3) stable; urgency=medium
+
+  * Remove restriction on rule file name
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 08 Apr 2024 14:28:00 +0400
+
 wb-rules (2.20.2) stable; urgency=medium
 
   * Show alarm titles

--- a/wbrules/editor.go
+++ b/wbrules/editor.go
@@ -4,13 +4,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/wirenboard/wbgong"
 )
-
-var editorPathRx = regexp.MustCompile(`^[\w /-]{0,256}[\w -]{1,253}\.js$`)
 
 type Editor struct {
 	locFileManager LocFileManager
@@ -44,7 +41,6 @@ const (
 	EDITOR_ERROR_INVALID_LEN    = 1009
 )
 
-var invalidPathError = &EditorError{EDITOR_ERROR_INVALID_PATH, "File path should contains only digits, letters, whitespaces, '_' and '-' chars"}
 var invalidExtensionError = &EditorError{EDITOR_ERROR_INVALID_EXT, "File name should ends with .js"}
 var invalidLenError = &EditorError{EDITOR_ERROR_INVALID_LEN, "File path should be shorter than or equal to 512 chars"}
 var listDirError = &EditorError{EDITOR_ERROR_LISTDIR, "Error listing the directory"}
@@ -85,8 +81,6 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorSaveResponse) erro
 		return invalidExtensionError
 	} else if len(args.Path) > 512 {
 		return invalidLenError
-	} else if !editorPathRx.MatchString(pth) {
-		return invalidPathError
 	}
 
 	*reply = EditorSaveResponse{nil, pth, nil}

--- a/wbrules/editor_test.go
+++ b/wbrules/editor_test.go
@@ -248,10 +248,6 @@ func (s *EditorSuite) TestSaveFile() {
 		"sub/sample6.js":      "sample6 -- error",
 	})
 
-	s.VerifyRpcError("Save", objx.Map{"path": "../foo/bar.js", "content": "evilfile"},
-		EDITOR_ERROR_INVALID_PATH, "EditorError", invalidPathError.Error())
-	s.VerifyRpcError("Save", objx.Map{"path": "qqq/$$$rrr.js", "content": "lamefile"},
-		EDITOR_ERROR_INVALID_PATH, "EditorError", invalidPathError.Error())
 	s.verifySources(map[string]string{
 		"sample1.js":          "// sample1 (changed)",
 		"sample2.js":          "// sample2",

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -889,7 +889,7 @@ func (engine *ESEngine) LiveWriteScript(virtualPath, content string) error {
 		// LiveLoadFile for the file, but as the new content
 		// will be already registered with the contentTracker,
 		// duplicate reload will not happen
-		err = ioutil.WriteFile(cleanPath, []byte(content), 0777)
+		err = ioutil.WriteFile(cleanPath, []byte(content), 0644)
 		if err != nil {
 			r <- err
 			return


### PR DESCRIPTION
* Ограничение на имя скрипта было только при сохранении через UI, вручную можно было создать скрипт с любым именем и это работало.
* Поправил права с 777 на 644 на вновь создаваемые файлы правил
<img width="338" alt="Näyttökuva 2024-4-8 kello 15 05 43" src="https://github.com/wirenboard/wb-rules/assets/688044/acff37e7-afab-457e-a896-bfd7de283199">
