### PR TITLE
Fix log priority

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,3 @@
 buildDebGolangWbgo defaultTargets: 'bullseye-armhf bullseye-arm64',
+                   defaultWbGoSoBranch: 'feature/SOFT-4496',
                    defaultRunLintian: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,2 @@
 buildDebGolangWbgo defaultTargets: 'bullseye-armhf bullseye-arm64',
-                   defaultWbGoSoBranch: 'feature/SOFT-4496',
                    defaultRunLintian: true

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ amd64:
 
 test:
 	cp amd64.wbgo.so wbrules/wbgo.so
-	CC=x86_64-linux-gnu-gcc go test -v -trimpath -ldflags="-s -w" ./wbrules
+	CC=x86_64-linux-gnu-gcc go test -v -trimpath -ldflags="-s -w" -cover ./wbrules
 
 wb-rules: main.go wbrules/*.go
 	$(GO_ENV) $(GO) build -trimpath $(GO_FLAGS)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.21.0) stable; urgency=medium
+
+  * update wbgo.so library, fix log priority
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 14 Oct 2024 18:45:00 +0400
+
 wb-rules (2.20.19) stable; urgency=medium
 
   * update wbgo.so library, fix device meta cleanup

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350
-	github.com/wirenboard/wbgong v0.5.3
+	github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f
 	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/robfig/cron.v1 v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350
-	github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f
+	github.com/wirenboard/wbgong v0.5.4
 	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/robfig/cron.v1 v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350 h1:hjfTrSlSU/Mt2KGZXYMfWhkUJBW8/fmZP5dT4YepCts=
 github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350/go.mod h1:RBaIu9caMBuL6Xk32Ty04qAjl/5cVSfEdCQtbWzvMQ0=
-github.com/wirenboard/wbgong v0.5.3 h1:Ou2gwtlK3B4D2mBBExDMU30PPs4+2m8CrDBEBBjcecE=
-github.com/wirenboard/wbgong v0.5.3/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
+github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f h1:EBsNGSUynUtnQyzsmM8oMQHuP8aDq3/77WmI7dl0d0c=
+github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/alexcesaro/statsd.v2 v2.0.0 h1:FXkZSCZIH17vLCO5sO2UucTHsH9pc+17F6pl3JVCwMc=

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350 h1:hjfTrSlSU/Mt2KGZXYMfWhkUJBW8/fmZP5dT4YepCts=
 github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350/go.mod h1:RBaIu9caMBuL6Xk32Ty04qAjl/5cVSfEdCQtbWzvMQ0=
-github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f h1:EBsNGSUynUtnQyzsmM8oMQHuP8aDq3/77WmI7dl0d0c=
-github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
+github.com/wirenboard/wbgong v0.5.4 h1:XmMTvdbT4pduwOoyR/KoWzR4NQCkVdTb84xZoBvlpPg=
+github.com/wirenboard/wbgong v0.5.4/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/alexcesaro/statsd.v2 v2.0.0 h1:FXkZSCZIH17vLCO5sO2UucTHsH9pc+17F6pl3JVCwMc=

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func isSocket(path string) bool {
 
 func main() {
 
-	if os.Args[1] == "version" {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
 		fmt.Println(version)
 		os.Exit(0)
 	}


### PR DESCRIPTION
* https://github.com/wirenboard/wbgong/pull/17

Test instruction:
```sh
$ cat << EOF > /etc/wb-rules/rules.js
log.info('info');
log.warning('warning');
log.error('error');
log.debug('debug');
EOF
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"levels":{"0":6},"service":"wb-rules.service","limit":2}' | jq -r '.[1]|.level,.msg'
null
INFO: [rule info] info
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"levels":{"0":4},"service":"wb-rules.service","limit":1}' | jq -r '.[]|.level,.msg'
4
WARNING: [rule warning] warning
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"levels":{"0":3},"service":"wb-rules.service","limit":1}' | jq -r '.[]|.level,.msg'
3
ERROR: [rule error] error
$ echo "WB_RULES_OPTIONS=-debug" > /etc/default/wb-rules
$ systemctl restart wb-rules
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"levels":{"0":7},"service":"wb-rules.service","limit":1,"pattern":"[rule debug] debug"}' | jq -r '.[]|.level,.msg'
7
DEBUG: [rule debug] debug
```
* enable coverage summary:
```
coverage: 79.2% of statements
```
* [minor] fix crash with no args

Before:
```sh
$ wb-rules
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.main()
	github.com/wirenboard/wb-rules/main.go:46 +0x1504
```
After:
```sh
$ wb-rules
ERROR: 2024/10/14 15:25:43 must specify rule file/directory name(s)
```