### PR TITLE
Restore rule debugging switch state on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ defineVirtualDevice('my-virtual-device', {
           1: {en: 'Normal', ru: 'В норме'},
           2: {en: 'Warning', ru: 'Внимание'},
           3: {en: 'Crash', ru: 'Авария'}
-        }   
+        }
       },
     }
 });
@@ -1270,7 +1270,7 @@ defineRule("myRule", {
     // в постоянное хранилище можно записывать значения любого типа
     ps["var1"] = 42;
     ps["var2"] = "foo";
-    ps["var3"] = { name: "Temperature", value: 26.3 };
+    ps["var3"] = StorableObject({ name: "Temperature", value: 26.3 });
 
     // чтение из хранилища
     log("Value of var1: " + ps["var1"]);

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.21.1) stable; urgency=medium
+
+  * Restore rule debugging switch state on restart
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 17 Oct 2024 21:35:00 +0400
+
 wb-rules (2.21.0) stable; urgency=medium
 
   * update wbgo.so library, fix log priority

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -799,6 +799,9 @@ ReadyWaitLoop:
 	close(engine.readyCh)
 
 	wbgong.Info.Printf("the engine is ready")
+
+	engine.updateDebugEnabled()
+
 	// wbgong.Info.Printf("******** READY ********")
 	for {
 		select {

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -1242,12 +1242,14 @@ func (engine *RuleEngine) updateDebugEnabled() {
 			}
 
 			i, err := ctrl.GetValue()
-			val = i.(bool)
+			if err == nil {
+				val = i.(bool)
+			}
 			return err
 		})
 
 		if err != nil {
-			panic("No debug control in rule engine service device")
+			return
 		}
 
 		var set uint32 = ATOMIC_FALSE


### PR DESCRIPTION
### RCA
После старта значение контрола `Rule debugging` восстанавливается из `/var/lib/wirenboard/wbrules-vdev.db` при создании виртуального девайса, но это создание происходит до того, как `mainLoop` запущен, как следствие `updateDebugEnabled` не вызывается при старте и `debugEnabled` остается False по дефолту.

### Test instruction
term 1:
```sh
$ echo "log.debug('test');" > /etc/wb-rules/rules.js
$ systemctl restart wb-rules
$ mqtt-get-dump "/devices/wbrules/controls/Rule debugging"
/devices/wbrules/controls/Rule debugging	1
```

term 2:
```sh
$ mosquitto_sub -t "/wbrules/log/debug"
defineRule: _system_buzzer_params
defineRule: _system_buzzer_onof
defineRule: _system_track_vin
defineRule: _system_reboot
defineRule: _reset_calib
test
```

### Misc
Заодно поправил readme, без `StorableObject(...)` сохранение объекта в персистентное хранилище не работает.