### PR TITLE
Do not trigger whenChanged on first published value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.22.0) stable; urgency=medium
+
+  * Do not trigger whenChanged on first published value, except for pushbutton control type
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 24 Oct 2024 19:33:59 +0500
+
 wb-rules (2.21.1) stable; urgency=medium
 
   * Restore rule debugging switch state on restart

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -399,6 +399,7 @@ func (ctrlProxy *ControlProxy) SetMeta(key, metaValue string) (cce *ControlChang
 	var spec ControlSpec
 	isComplete := false
 	isRetained := false
+	var controlType string
 	var prevMetaValue interface{}
 
 	isLocal := false
@@ -410,6 +411,7 @@ func (ctrlProxy *ControlProxy) SetMeta(key, metaValue string) (cce *ControlChang
 		}
 		isComplete = ctrl.IsComplete()
 		isRetained = ctrl.IsRetained()
+		controlType = ctrl.GetType()
 
 		allMeta := ctrl.GetMeta()
 		var ok bool
@@ -481,11 +483,12 @@ func (ctrlProxy *ControlProxy) SetMeta(key, metaValue string) (cce *ControlChang
 		return
 	}
 	cce = &ControlChangeEvent{
-		Spec:       spec,
-		IsComplete: isComplete,
-		IsRetained: isRetained,
-		Value:      metaValue,
-		PrevValue:  prevMetaValue,
+		Spec:        spec,
+		ControlType: controlType,
+		IsComplete:  isComplete,
+		IsRetained:  isRetained,
+		Value:       metaValue,
+		PrevValue:   prevMetaValue,
 	}
 	return
 }
@@ -524,11 +527,12 @@ func (cp cronProxy) AddFunc(spec string, cmd func()) error {
 
 // ControlChangeEvent
 type ControlChangeEvent struct {
-	Spec       ControlSpec
-	IsComplete bool
-	IsRetained bool
-	Value      interface{}
-	PrevValue  interface{}
+	Spec        ControlSpec
+	ControlType string
+	IsComplete  bool
+	IsRetained  bool
+	Value       interface{}
+	PrevValue   interface{}
 }
 
 type RuleEngineOptions struct {
@@ -840,6 +844,7 @@ func (engine *RuleEngine) driverEventHandler(event wbgong.DriverEvent) {
 	var spec ControlSpec
 	isComplete := false
 	isRetained := false
+	var controlType string
 
 	switch e := event.(type) {
 	case wbgong.ControlValueEvent:
@@ -860,12 +865,14 @@ func (engine *RuleEngine) driverEventHandler(event wbgong.DriverEvent) {
 
 		isComplete = ctrl.IsComplete()
 		isRetained = ctrl.IsRetained()
+		controlType = ctrl.GetType()
 	case wbgong.NewExternalDeviceControlMetaEvent:
 		ctrl := e.Control
 		spec = ControlSpec{ctrl.GetDevice().GetId(), ctrl.GetId()}
 
 		isComplete = ctrl.IsComplete()
 		isRetained = ctrl.IsRetained()
+		controlType = ctrl.GetType()
 
 		var err error
 
@@ -887,11 +894,12 @@ func (engine *RuleEngine) driverEventHandler(event wbgong.DriverEvent) {
 		metaSpec := ControlSpec{e.Control.GetDevice().GetId(), metaCtrl}
 
 		metaCCE := &ControlChangeEvent{
-			Spec:       metaSpec,
-			IsComplete: isComplete,
-			IsRetained: isRetained,
-			Value:      e.Value,
-			PrevValue:  e.PrevValue,
+			Spec:        metaSpec,
+			ControlType: controlType,
+			IsComplete:  isComplete,
+			IsRetained:  isRetained,
+			Value:       e.Value,
+			PrevValue:   e.PrevValue,
 		}
 		engine.eventBuffer.PushEvent(metaCCE)
 	default:
@@ -899,11 +907,12 @@ func (engine *RuleEngine) driverEventHandler(event wbgong.DriverEvent) {
 	}
 
 	cce := &ControlChangeEvent{
-		Spec:       spec,
-		IsComplete: isComplete,
-		IsRetained: isRetained,
-		Value:      value,
-		PrevValue:  prevValue,
+		Spec:        spec,
+		ControlType: controlType,
+		IsComplete:  isComplete,
+		IsRetained:  isRetained,
+		Value:       value,
+		PrevValue:   prevValue,
 	}
 
 	engine.eventBuffer.PushEvent(cce)

--- a/wbrules/rule.go
+++ b/wbrules/rule.go
@@ -135,7 +135,7 @@ func (ruleCond *CellChangedRuleCondition) Check(e *ControlChangeEvent) (bool, in
 		return false, nil
 	}
 
-	if e.IsRetained && e.PrevValue == e.Value {
+	if (e.ControlType != "pushbutton" && e.PrevValue == nil) || (e.IsRetained && e.PrevValue == e.Value) {
 		return false, nil
 	}
 

--- a/wbrules/rule.go
+++ b/wbrules/rule.go
@@ -135,7 +135,7 @@ func (ruleCond *CellChangedRuleCondition) Check(e *ControlChangeEvent) (bool, in
 		return false, nil
 	}
 
-	if (e.ControlType != "pushbutton" && e.PrevValue == nil) || (e.IsRetained && e.PrevValue == e.Value) {
+	if (e.ControlType != wbgong.CONV_TYPE_PUSHBUTTON && e.PrevValue == nil) || (e.IsRetained && e.PrevValue == e.Value) {
 		return false, nil
 	}
 

--- a/wbrules/rule_basics_test.go
+++ b/wbrules/rule_basics_test.go
@@ -101,18 +101,22 @@ func (s *RuleBasicsSuite) TestDirectMQTTMessages() {
 
 func (s *RuleBasicsSuite) TestCellChange() {
 	s.publish("/devices/somedev/controls/foobarbaz/meta/type", "text", "somedev/foobarbaz")
+	s.publish("/devices/somedev/controls/foobarbaz", "initial_text", "somedev/foobarbaz")
 	s.publish("/devices/somedev/controls/foobarbaz", "abc", "somedev/foobarbaz")
 	s.Verify(
 		"tst -> /devices/somedev/controls/foobarbaz/meta/type: [text] (QoS 1, retained)",
+		"tst -> /devices/somedev/controls/foobarbaz: [initial_text] (QoS 1, retained)",
 		"tst -> /devices/somedev/controls/foobarbaz: [abc] (QoS 1, retained)",
 		"[info] cellChange1: somedev/foobarbaz=abc (string)",
 		"[info] cellChange2: somedev/foobarbaz=abc (string)",
 	)
 
 	s.publish("/devices/somedev/controls/tempx/meta/type", "temperature", "somedev/tempx")
+	s.publish("/devices/somedev/controls/tempx", "0", "somedev/tempx")
 	s.publish("/devices/somedev/controls/tempx", "42", "somedev/tempx")
 	s.Verify(
 		"tst -> /devices/somedev/controls/tempx/meta/type: [temperature] (QoS 1, retained)",
+		"tst -> /devices/somedev/controls/tempx: [0] (QoS 1, retained)",
 		"tst -> /devices/somedev/controls/tempx: [42] (QoS 1, retained)",
 		"[info] cellChange2: somedev/tempx=42 (number)",
 	)

--- a/wbrules/rule_read_config_test.go
+++ b/wbrules/rule_read_config_test.go
@@ -51,13 +51,17 @@ func (s *RuleReadConfigSuite) verifyReadConfRuleLog(configPath string, msgs ...i
 
 func (s *RuleReadConfigSuite) TestReadConfig() {
 	configPath := s.WriteConfig("conf.json", "{ // whatever! \n/*\nmultiline\ncomment!\n*/\n\"xyz\": 42 }")
+	s.publish("/devices/somedev/controls/readSampleConfig", "initial_text", "somedev/readSampleConfig")
 	s.TryReadingConfig(configPath)
+	s.Verify("tst -> /devices/somedev/controls/readSampleConfig: [initial_text] (QoS 1, retained)")
 	s.verifyReadConfRuleLog(configPath, "[info] config: {\"xyz\":42}")
 }
 
 func (s *RuleReadConfigSuite) TestReadConfigErrors() {
 	configPath := filepath.Join(s.configDir, "nosuchconf.json")
+	s.publish("/devices/somedev/controls/readSampleConfig", "initial_text", "somedev/readSampleConfig")
 	s.TryReadingConfig(configPath)
+	s.Verify("tst -> /devices/somedev/controls/readSampleConfig: [initial_text] (QoS 1, retained)")
 	s.verifyReadConfRuleLog(
 		configPath,
 		fmt.Sprintf("[error] failed to open config file: %s", configPath),

--- a/wbrules/rule_shell_command_test.go
+++ b/wbrules/rule_shell_command_test.go
@@ -41,10 +41,12 @@ func (s *RuleShellCommandSuite) TestRunShellCommand() {
 	s.publish("/devices/somedev/controls/cmd/meta/type", "text", "somedev/cmd")
 	s.publish("/devices/somedev/controls/cmdNoCallback/meta/type", "text",
 		"somedev/cmdNoCallback")
+	s.publish("/devices/somedev/controls/cmd", "initial_text", "somedev/cmd")
 	s.publish("/devices/somedev/controls/cmd", "touch samplefile.txt", "somedev/cmd")
 	s.Verify(
 		"tst -> /devices/somedev/controls/cmd/meta/type: [text] (QoS 1, retained)",
 		"tst -> /devices/somedev/controls/cmdNoCallback/meta/type: [text] (QoS 1, retained)",
+		"tst -> /devices/somedev/controls/cmd: [initial_text] (QoS 1, retained)",
 		"tst -> /devices/somedev/controls/cmd: [touch samplefile.txt] (QoS 1, retained)",
 		"[info] cmd: touch samplefile.txt",
 		"[info] exit(0): touch samplefile.txt",
@@ -75,10 +77,13 @@ func (s *RuleShellCommandSuite) TestRunShellCommand() {
 func (s *RuleShellCommandSuite) TestRunShellCommandIO() {
 	s.publish("/devices/somedev/controls/cmdWithOutput/meta/type", "text",
 		"somedev/cmdWithOutput")
+	s.publish("/devices/somedev/controls/cmdWithOutput", "initial_text",
+		"somedev/cmdWithOutput")
 	s.publish("/devices/somedev/controls/cmdWithOutput", "echo abc; echo qqq",
 		"somedev/cmdWithOutput")
 	s.Verify(
 		"tst -> /devices/somedev/controls/cmdWithOutput/meta/type: [text] (QoS 1, retained)",
+		"tst -> /devices/somedev/controls/cmdWithOutput: [initial_text] (QoS 1, retained)",
 		"tst -> /devices/somedev/controls/cmdWithOutput: [echo abc; echo qqq] (QoS 1, retained)",
 		"[info] cmdWithOutput: echo abc; echo qqq",
 		"[info] exit(0): echo abc; echo qqq",
@@ -115,11 +120,13 @@ func (s *RuleShellCommandSuite) TestCallbackCleanup() {
 	s.publish("/devices/somedev/controls/cmdNoCallback/meta/type", "text",
 		"somedev/cmdNoCallback")
 
+	s.publish("/devices/somedev/controls/cmd", "initial_text", "somedev/cmd")
 	s.publish("/devices/somedev/controls/cmd", "until [ -f fflag ]; do sleep 0.1; done", "somedev/cmd")
 
 	s.Verify(
 		"tst -> /devices/somedev/controls/cmd/meta/type: [text] (QoS 1, retained)",
 		"tst -> /devices/somedev/controls/cmdNoCallback/meta/type: [text] (QoS 1, retained)",
+		"tst -> /devices/somedev/controls/cmd: [initial_text] (QoS 1, retained)",
 		"tst -> /devices/somedev/controls/cmd: [until [ -f fflag ]; do sleep 0.1; done] (QoS 1, retained)",
 		"[info] cmd: until [ -f fflag ]; do sleep 0.1; done",
 	)


### PR DESCRIPTION
Мотивация [тут](https://wirenboard.youtrack.cloud/issue/SOFT-3052/Otrabotka-pravil-zavyazannyh-na-schetchiki)

Не вызываем `whenChanged` при первой публикации в топик, либо, если перед этим публиковали null. Исключение только для типа pushbutton