### PR TITLE
Encode email alerts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-rules (2.22.1) stable; urgency=medium
 
-  * 
+  * Fix e-mail encoding in alarms
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 06 Nov 2024 18:48:31 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.22.1) stable; urgency=medium
+
+  * 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 06 Nov 2024 18:48:31 +0500
+
 wb-rules (2.22.0) stable; urgency=medium
 
   * Do not trigger whenChanged on first published value, except for pushbutton control type

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -435,7 +435,7 @@ var Notify = (function () {
       runShellCommand("/usr/sbin/sendmail '{}'".format(to), {
         captureErrorOutput: true,
         captureOutput: true,
-        input: 'Subject: =?utf-8?B?{}?=\r\nContent-Type: text/plain; charset=utf-8\r\n{}'.format(base64subject, text),
+        input: 'Subject: =?utf-8?B?{}?=\r\nContent-Type: text/plain; charset=utf-8\n\n{}'.format(base64subject, text),
         exitCallback: function exitCallback(exitCode, capturedOutput, capturedErrorOutput) {
           if (exitCode != 0)
             log.error(

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -431,7 +431,7 @@ var Notify = (function () {
   return {
     sendEmail: function sendEmail(to, subject, text) {
       log('sending email to {}: {}', to, subject);
-      var base64subject = Buffer.from(subject).toString('base64');
+      var base64subject = Duktape.enc('base64', subject);
       runShellCommand("/usr/sbin/sendmail '{}'".format(to), {
         captureErrorOutput: true,
         captureOutput: true,

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -431,7 +431,7 @@ var Notify = (function () {
   return {
     sendEmail: function sendEmail(to, subject, text) {
       log('sending email to {}: {}', to, subject);
-      base64subject = Buffer.from(subject).toString('base64');
+      var base64subject = Buffer.from(subject).toString('base64');
       runShellCommand("/usr/sbin/sendmail '{}'".format(to), {
         captureErrorOutput: true,
         captureOutput: true,

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -431,10 +431,11 @@ var Notify = (function () {
   return {
     sendEmail: function sendEmail(to, subject, text) {
       log('sending email to {}: {}', to, subject);
+      base64subject = Buffer.from(subject).toString('base64');
       runShellCommand("/usr/sbin/sendmail '{}'".format(to), {
         captureErrorOutput: true,
         captureOutput: true,
-        input: 'Subject: {}\n\n{}'.format(subject, text),
+        input: 'Subject: =?utf-8?B?{}?=\r\nContent-Type: text/plain; charset=utf-8\r\n{}'.format(base64subject, text),
         exitCallback: function exitCallback(exitCode, capturedOutput, capturedErrorOutput) {
           if (exitCode != 0)
             log.error(


### PR DESCRIPTION
Некоторые почтовые клиенты не трактуют название и тело письма как utf-8. Большинство современных клиентов имеют такую эвристику. Поправил заголовки письма, чтобы все были довольны

Бывало вот так
![изображение](https://github.com/user-attachments/assets/1a019822-cf74-408b-81a4-e97deb4649ac)

https://wirenboard.youtrack.cloud/issue/SOFT-4569/Problema-s-kodirovkoj-vo-vneshnem-kliente