### PR TITLE
Bugfix/2g modems

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.28.4) stable; urgency=medium
+
+  * Fix sms sending via 2G/3G modems
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 10 Apr 2025 15:15:27 +0300
+
 wb-rules (2.28.3) stable; urgency=medium
 
   * document reading of non-existent meta topics

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -418,10 +418,11 @@ var Notify = (function () {
     });
   }
 
-  function _checkHasModemManager(doneCallback) {
-    // in case of using 4g modems with MM this service will be running
+  function _checkUse4gModem(doneCallback) {
+    // in case of using 4g modems wb-gsm.service must be started
+    // so check its ExecCondition
     // in case of using 2G,3G modems this service will be stopped
-    runShellCommand('systemctl status wb-gsm', {
+    runShellCommand('wb-gsm should_enable', {
       captureOutput: true,
       captureErrorOutput: true,
       exitCallback: function (exitCode) {
@@ -473,7 +474,7 @@ var Notify = (function () {
           _sendSMSGammuLike(to, text, command, doneCallback);
         });
       } else {
-        _checkHasModemManager(function (hasModemManager) {
+        _checkUse4gModem(function (hasModemManager) {
           if (hasModemManager) {
             sendOrEnqueue(function () {
               _sendSMSModemManager(to, text, doneCallback);

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -419,7 +419,9 @@ var Notify = (function () {
   }
 
   function _checkHasModemManager(doneCallback) {
-    runShellCommand('mmcli --version', {
+    // in case of using 4g modems with MM this service will be running
+    // in case of using 2G,3G modems this service will be stopped
+    runShellCommand('systemctl status wb-gsm', {
       captureOutput: true,
       captureErrorOutput: true,
       exitCallback: function (exitCode) {

--- a/wbrules/rule_notify_sms_test.go
+++ b/wbrules/rule_notify_sms_test.go
@@ -33,7 +33,7 @@ func (s *RuleNotifySmsSuite) TestSmsGammu() {
 	s.VerifyUnordered(
 		"driver -> /devices/test_sms/controls/send: [1] (QoS 1)",
 		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: systemctl status wb-gsm] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (gammu-like) to 88005553535: test value] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm restart_if_broken && gammu sendsms TEXT '88005553535' -unicode] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [input: test value] (QoS 1)",
@@ -48,7 +48,7 @@ func (s *RuleNotifySmsSuite) TestSmsModemManager() {
 	s.VerifyUnordered(
 		"driver -> /devices/test_sms/controls/send: [1] (QoS 1)",
 		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: systemctl status wb-gsm] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager) to 88005553535: test value] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test value\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",
 	)
@@ -62,7 +62,7 @@ func (s *RuleNotifySmsSuite) TestSmsModemManagerWithQuotes() {
 	s.VerifyUnordered(
 		"driver -> /devices/test_sms/controls/send_quoted: [1] (QoS 1)",
 		"tst -> /devices/test_sms/controls/send_quoted/on: [1] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: systemctl status wb-gsm] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager) to 88005553535: test \"value\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/warning: [ModemManager can't handle SMS with double quotes now, auto replaced with single ones] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test 'value' 'single'\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",

--- a/wbrules/rule_notify_sms_test.go
+++ b/wbrules/rule_notify_sms_test.go
@@ -33,7 +33,7 @@ func (s *RuleNotifySmsSuite) TestSmsGammu() {
 	s.VerifyUnordered(
 		"driver -> /devices/test_sms/controls/send: [1] (QoS 1)",
 		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: mmcli --version] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: systemctl status wb-gsm] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (gammu-like) to 88005553535: test value] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm restart_if_broken && gammu sendsms TEXT '88005553535' -unicode] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [input: test value] (QoS 1)",
@@ -48,7 +48,7 @@ func (s *RuleNotifySmsSuite) TestSmsModemManager() {
 	s.VerifyUnordered(
 		"driver -> /devices/test_sms/controls/send: [1] (QoS 1)",
 		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: mmcli --version] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: systemctl status wb-gsm] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager) to 88005553535: test value] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test value\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",
 	)
@@ -62,7 +62,7 @@ func (s *RuleNotifySmsSuite) TestSmsModemManagerWithQuotes() {
 	s.VerifyUnordered(
 		"driver -> /devices/test_sms/controls/send_quoted: [1] (QoS 1)",
 		"tst -> /devices/test_sms/controls/send_quoted/on: [1] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: mmcli --version] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: systemctl status wb-gsm] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager) to 88005553535: test \"value\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/warning: [ModemManager can't handle SMS with double quotes now, auto replaced with single ones] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test 'value' 'single'\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Не работала отправка смс на старых модемах wb6 с новым релизом, сделали чтоб работало
___________________________________
**Что поменялось для пользователей:**

Теперь отправляются смс на старых модемах
___________________________________
**Как проверял/а:**

На контроллере у Андрея Радионова отправляла смски себе в правиле, wb6 + 2g модем
![изображение](https://github.com/user-attachments/assets/d08f8290-4085-4ad8-9679-a3962de9c518)
![изображение](https://github.com/user-attachments/assets/f97cf45c-cdb2-4b1b-9698-bdb23eebcd17)



