### PR TITLE
Fix enableRule/disableRule for cron rules

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.30.0) stable; urgency=medium
+
+  * Fix enableRule/disableRule for cron rules
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 19 May 2025 17:30:00 +0400
+
 wb-rules (2.29.0) stable; urgency=medium
 
   * Delete from persistent storage when writing null or undefined value

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7
 	github.com/alexcesaro/statsd v2.0.0+incompatible
 	github.com/boltdb/bolt v0.0.0-20161223174454-2e25e3bb4285
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350
 	github.com/wirenboard/wbgong v0.5.10
-	gopkg.in/robfig/cron.v1 v1.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
@@ -25,7 +27,5 @@ gopkg.in/alexcesaro/statsd.v2 v2.0.0 h1:FXkZSCZIH17vLCO5sO2UucTHsH9pc+17F6pl3JVC
 gopkg.in/alexcesaro/statsd.v2 v2.0.0/go.mod h1:i0ubccKGzBVNBpdGV5MocxyA/XlLUJzA7SLonnE4drU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/robfig/cron.v1 v1.2.0 h1:PSJsm0uPEND0Rumxxbo7qNb7bxQUTIWDIdpPS59/tcw=
-gopkg.in/robfig/cron.v1 v1.2.0/go.mod h1:3I22DCB+7VAStCIqyArwi2xY9a7IioCiNjrsnCqs+HE=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -2332,7 +2332,7 @@ func (engine *ESEngine) esWbCtrlRule(ctx *ESContext, state bool) int {
 	ruleId := RuleId(ctx.GetInt(0))
 
 	if rule, found := engine.ruleMap[ruleId]; found {
-		rule.enabled = state
+		rule.SetState(state, engine.cron)
 	} else {
 		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("trying to %s undefined rule: %d", act, ruleId))
 		return duktape.DUK_RET_ERROR


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
enableRule/disableRule не работало с cron правилами.

Понадобилось обновить cron модуль с v1 на v3, где добавлена поддержка удаления cron задания. Основное изменение между v1 и v3 это изменение формата спеки по дефолту с Quartz Scheduler на стандартный линуксовый формат. Чтобы не ломать совместимость включил Quartz Scheduler для спеки, как это было с v1.
Diff: https://github.com/robfig/cron/compare/v1.2.0...v3.0.1
___________________________________
**Что поменялось для пользователей:**
enableRule/disableRule работает с cron правилами.

___________________________________
**Как проверял/а:**

```js
defineVirtualDevice('test_cron', {
  cells: {
    enabled: {
      type: "switch",
      value: true
    }
  }
});

var cronRule = defineRule({
  when: cron("* * * * * *"),
  then: function() {
    log.info("test");
  }
});

defineRule({
  whenChanged: "test_cron/enabled",
  then: function(newValue, devName, cellName) {
    if (newValue) {
      log.info("enableRule");
      enableRule(cronRule);
    } else {
      log.info("disableRule");
      disableRule(cronRule);
    }
  }
});
```

