### PR TITLE
Fix rule defining from 'then' function

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.31.0) stable; urgency=medium
+
+  * Fix rule defining from 'then' function
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 21 May 2025 09:30:00 +0400
+
 wb-rules (2.30.0) stable; urgency=medium
 
   * Fix enableRule/disableRule for cron rules

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -1195,7 +1195,6 @@ func (engine *RuleEngine) RunRules(ctrlEvent *ControlChangeEvent, timerName stri
 		wbgong.Debug.Printf("[ruleengine] RulesLists for all: %v", engine.controlToRulesListMap)
 	}
 	engine.rulesMutex.Lock()
-	defer engine.rulesMutex.Unlock()
 
 	// select all uninitialized rules to run and clean list
 	for _, rule := range engine.uninitializedRules {
@@ -1234,8 +1233,14 @@ func (engine *RuleEngine) RunRules(ctrlEvent *ControlChangeEvent, timerName stri
 		}
 	}
 
-	for _, ruleId := range engine.ruleList {
-		engine.ruleMap[ruleId].Check(ctrlEvent)
+	rulesToRun := make([]*Rule, len(engine.ruleList))
+	for i, ruleId := range engine.ruleList {
+		rulesToRun[i] = engine.ruleMap[ruleId]
+	}
+	engine.rulesMutex.Unlock()
+
+	for _, rule := range rulesToRun {
+		rule.Check(ctrlEvent)
 	}
 	engine.currentTimer = NO_TIMER_NAME
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При вызове defineRule из then функции wb-rules переставал работать.
Причина в том, что мы захватываем мьютекс тут https://github.com/wirenboard/wb-rules/blob/73212813fc34242510513325e8522954a9a343f4/wbrules/engine.go#L1197 на время запуска правил, но при вызове defineRule тоже пытаемся захватить мьютекс тут https://github.com/wirenboard/wb-rules/blob/73212813fc34242510513325e8522954a9a343f4/wbrules/engine.go#L1878, на чем и зависаем навечно.

___________________________________
**Что поменялось для пользователей:**
defineRule из then функции работает и не ломает wb-rules

___________________________________
**Как проверял/а:**
```js
defineVirtualDevice("test_rule", {
  cells: {
    define: {
      type: "pushbutton"
    }
  }
});

cnt = 0;
defineRule({
  whenChanged: "test_rule/define",
  then: function() {
    cnt++;
    var currentCnt = cnt;
    log.info("define", currentCnt);
    defineRule({
      when: cron("@every 2s"),
      then: function () {
        log.info("rule", currentCnt);
      },
    });
  },
});
```


