### PR TITLE
Return undefined from addControl

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.31.1) stable; urgency=medium
+
+  * Return undefined from addControl in rules
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 27 May 2025 18:07:36 +0500
+
 wb-rules (2.31.0) stable; urgency=medium
 
   * Fix rule defining from 'then' function

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -1479,7 +1479,7 @@ func (engine *ESEngine) esVdevAddControl(ctx *ESContext) int {
 	if errControl != nil {
 		wbgong.Error.Printf("Error in creating control %s on device %s: %s", ctrlId, devId, errControl)
 	}
-	return 1
+	return 0
 }
 
 func (engine *ESEngine) esVdevCellGetDescription(ctx *ESContext) int {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
```
var result = device.addControl(controlName, controlConfig);
```
Возвращает `controlConfig`, хотя ожидаем, что ничего не должно возвращаться

___________________________________
**Что поменялось для пользователей:**
Возвращается `undefined`

___________________________________
**Как проверял/а:**
Привет в задаче https://wirenboard.youtrack.cloud/issue/SOFT-5333/Vozvrashaemoe-znachenie-pri-vyzove-addControl


