### PR TITLE
Add script error logging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.32.1) stable; urgency=medium
+
+  * Add script error logging
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 18 Jun 2025 00:30:00 +0400
+
 wb-rules (2.32.0) stable; urgency=medium
 
   * Rework metrics

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -827,6 +827,7 @@ func (engine *ESEngine) trackESError(path string, err error) error {
 	// set error in the file entry
 	engine.sources[path].Error = &scriptErr
 
+	engine.Log(ENGINE_LOG_ERROR, scriptErr.Error())
 	return scriptErr
 }
 

--- a/wbrules/rule_basics_test.go
+++ b/wbrules/rule_basics_test.go
@@ -242,6 +242,10 @@ func (s *RuleBasicsSuite) TestRuleRedefinition() {
 	s.LiveLoadScript("testrules_rule_redefinition.js")
 	s.EnsureGotErrors()
 	s.SkipTill("[error] defineRule error: named rule redefinition: test")
+	s.Verify(testutils.RegexpCaptureMatcher(
+		`.*Error: error error \(rc -100\).*`, func(m []string) bool {
+			return true
+		}))
 	s.Verify("[changed] testrules_rule_redefinition.js")
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Не пойманные исключения из скрипта никак не отображались в логах (только если это произошло при сохранении скрипта в редакторе, то показывается плашка с ошибкой), пользователям сложно заметить проблему в таких случаях.

___________________________________
**Что поменялось для пользователей:**
Исключение логируется как в журнал, так и в лог рулесов:

![Screen Shot 2025-06-18 at 16 18 13](https://github.com/user-attachments/assets/79f35aa4-6ccd-4c88-9d21-494c1dff4401)
![Screen Shot 2025-06-18 at 16 18 51](https://github.com/user-attachments/assets/30fdfe4d-1451-4ab7-ab46-d32b22c7a9e6)


___________________________________
**Как проверял/а:**
на контроллере, используя правило от автора таски

