### PR TITLE
Fix requests/messages queue size

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,3 @@
 buildDebGolangWbgo defaultTargets: 'bullseye-armhf bullseye-arm64',
+                   defaultWbGoSoBranch: 'feature/fix-queue-len',
                    defaultRunLintian: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,2 @@
 buildDebGolangWbgo defaultTargets: 'bullseye-armhf bullseye-arm64',
-                   defaultWbGoSoBranch: 'feature/fix-queue-len',
                    defaultRunLintian: true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.33.0) stable; urgency=medium
+
+  * Fix requests/messages queue size, update wbgo.so library
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 27 Jun 2025 18:00:00 +0400
+
 wb-rules (2.32.2) stable; urgency=medium
 
   * Fix local build, no functional changes


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
У очередей были нулевые размеры. Это приводило например к полному зависанию wb-rules при повторном сохранении в редакторе правила в котором объявлены контролы с lazyInit=true.
До:
```
curl -s http://127.0.0.1:9090/metrics | grep wbgo_backend_ | grep capacity_total
wbgo_backend_msg_queue_capacity_total 0
wbgo_backend_req_queue_capacity_total 0
```
После:
```
curl -s http://127.0.0.1:9090/metrics | grep wbgo_backend_ | grep capacity_total
wbgo_backend_msg_queue_capacity_total 32
wbgo_backend_req_queue_capacity_total 32
```

___________________________________
**Что поменялось для пользователей:**
wb-rules не зависает в вышеописаной ситуации

___________________________________
**Как проверял/а:**
на контроллере

