### PR TITLE
Added a channel to send messages to telegram chat with the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,9 @@ var myModule = require("path/to/myModule");
 
 Для отправки SMS используется ModemManager, а если он не установлен, то `gammu`.
 
+`Notify.sendTelegramMessage(token, chatId, text)` отправляет сообщение
+боту с токеном `token`, в чат `chatId` и содержимым (`text`).
+
 ## Сервис алармов
 
 Основная функция:
@@ -1173,6 +1176,16 @@ var myModule = require("path/to/myModule");
       // /path/to/sender.py --number {}
       // /path/to/sender.py --number {} --text "{}"
       "command": ""
+    },
+    {
+      // Тип получателя - Telegram-бот
+      "type": "telegram",
+
+      // Токен бота
+      "token": "1234567890:AAHG7MAKsUHLs-pBLhpIw1RU07Hmw9LyDac",
+
+      // Идентификатор чата с пользователем
+      "chatId": "123456789"
     }
   ],
 

--- a/README.md
+++ b/README.md
@@ -1104,6 +1104,8 @@ var myModule = require("path/to/myModule");
 `Notify.sendEmail(to, subject, text)` отправляет почту указанному
 адресату (`to`), с указанной темой (`subject`) и содержимым (`text`).
 
+Для отправки Email используется `sendmail`.
+
 `Notify.sendSMS(to, text, command)` отправляет SMS на указанный номер (`to`)
 с указанным содержимым (`text`), используя команду (`command`) (необязательный аргумент).
 
@@ -1111,6 +1113,8 @@ var myModule = require("path/to/myModule");
 
 `Notify.sendTelegramMessage(token, chatId, text)` отправляет сообщение
 боту с токеном `token`, в чат `chatId` и содержимым (`text`).
+
+Для отправки используется Telegram Bot API метод https://core.telegram.org/bots/api#sendmessage.
 
 ## Сервис алармов
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.34.0) stable; urgency=medium
+
+  * Added a channel to send messages to telegram chat with the bot
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 01 Jul 2025 14:00:00 +0400
+
 wb-rules (2.33.0) stable; urgency=medium
 
   * Fix requests/messages queue size, update wbgo.so library

--- a/rules/alarms-restricted.schema.json
+++ b/rules/alarms-restricted.schema.json
@@ -63,6 +63,36 @@
       },
       "required": ["type", "to"]
     },
+    "telegramRecipient": {
+      "title": "Telegram Bot",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "enum": ["telegram"],
+          "default": "telegram",
+          "options": {
+            "hidden": true
+          },
+          "propertyOrder": 1
+        },
+        "token": {
+          "type": "string",
+          "title": "Bot token",
+          "description": "A token can be obtained from @BotFather",
+          "minLength": 1,
+          "propertyOrder": 2
+        },
+        "chatId": {
+          "type": "string",
+          "title": "Chat ID",
+          "description": "The chat ID can be obtained from @getidsbot",
+          "propertyOrder": 3
+        }
+      },
+      "required": ["type", "token", "chatId"]
+    },
     "alarmBase": {
       "type": "object",
       "properties": {
@@ -214,7 +244,8 @@
       "title" : "Recipient",
       "oneOf": [
         { "$ref": "#/definitions/emailRecipient" },
-        { "$ref": "#/definitions/smsRecipient" }
+        { "$ref": "#/definitions/smsRecipient" },
+        { "$ref": "#/definitions/telegramRecipient" }
       ],
       "options": {
         "disable_collapse" : true

--- a/rules/alarms.schema.json
+++ b/rules/alarms.schema.json
@@ -63,6 +63,36 @@
             },
             "required": ["type", "to"]
         },
+        "telegramRecipient": {
+            "title": "Telegram Bot",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "enum": ["telegram"],
+                    "default": "telegram",
+                    "options": {
+                        "hidden": true
+                    },
+                    "propertyOrder": 1
+                },
+                "token": {
+                    "type": "string",
+                    "title": "Bot token",
+                    "description": "A token can be obtained from @BotFather",
+                    "minLength": 1,
+                    "propertyOrder": 2
+                },
+                "chatId": {
+                    "type": "string",
+                    "title": "Chat ID",
+                    "description": "The chat ID can be obtained from @getidsbot",
+                    "propertyOrder": 3
+                }
+            },
+            "required": ["type", "token", "chatId"]
+        },
         "alarmBase": {
             "type": "object",
             "properties": {
@@ -265,7 +295,8 @@
             "title": "Recipient",
             "oneOf": [
                 { "$ref": "#/definitions/emailRecipient" },
-                { "$ref": "#/definitions/smsRecipient" }
+                { "$ref": "#/definitions/smsRecipient" },
+                { "$ref": "#/definitions/telegramRecipient" }
             ]
         },
         "alarm": {
@@ -348,6 +379,11 @@
             "{} will be replaced with alarm message text": "{} будет заменено на текст сообщения",
             "SMS recipient": "SMS-сообщение",
             "Phone number": "Номер телефона",
+            "Telegram Bot": "Телеграм бот",
+            "Bot token": "Токен бота",
+            "A token can be obtained from @BotFather": "Токен можно получить через @BotFather",
+            "Chat ID": "Идентификатор чата",
+            "The chat ID can be obtained from @getidsbot": "Идентификатор можно получить через @getidsbot",
             "Command": "Команда",
             "Alarm name": "Название уведомления",
             "Cell": "Отслеживаемый параметр",

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -507,6 +507,14 @@ var Notify = (function () {
                 capturedOutput,
                 capturedErrorOutput
               );
+            var response = JSON.parse(capturedOutput);
+            if (!response.ok)
+              log.error(
+                'error sending telegram message to {}:\n{} {}',
+                chatId,
+                response.error_code,
+                response.description
+              );
           },
         }
       );

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -487,6 +487,30 @@ var Notify = (function () {
         });
       }
     },
+
+    sendTelegramMessage: function sendTelegramMessage(token, chatId, text) {
+      log('sending telegram message to {}', chatId);
+      runShellCommand(
+        "curl -s -X POST https://api.telegram.org/bot{}/sendMessage -d chat_id={} -d text='{}'".format(
+          token,
+          chatId,
+          encodeURIComponent(text)
+        ),
+        {
+          captureErrorOutput: true,
+          captureOutput: true,
+          exitCallback: function exitCallback(exitCode, capturedOutput, capturedErrorOutput) {
+            if (exitCode != 0)
+              log.error(
+                'error sending telegram message to {}:\n{}\n{}',
+                chatId,
+                capturedOutput,
+                capturedErrorOutput
+              );
+          },
+        }
+      );
+    },
   };
 })();
 
@@ -504,6 +528,13 @@ var Alarms = (function () {
       if (!src.hasOwnProperty('to')) throw new Error("sms recipient without 'to'");
       return function sendSMSWrapper(text) {
         Notify.sendSMS(src.to, text, src.command || '');
+      };
+    },
+
+    telegram: function getTelegramSendFunc(src) {
+      if (!src.hasOwnProperty('chatId')) throw new Error("telegram message recipient without 'chatId'");
+      return function sendTelegramWrapper(text) {
+        Notify.sendTelegramMessage(src.token, src.chatId, text);
       };
     },
   };

--- a/wbrules/alarms.conf
+++ b/wbrules/alarms.conf
@@ -15,6 +15,11 @@
     {
       "type": "sms",
       "to": "+78122128506"
+    },
+    {
+      "type": "telegram",
+      "token": "1234567890:AAHG7MAKsUHLs-pBLhpIw1RU07Hmw9LyDac",
+      "chatId": "123456789"
     }
   ],
   "alarms": [

--- a/wbrules/alarms1.conf
+++ b/wbrules/alarms1.conf
@@ -15,6 +15,11 @@
     {
       "type": "sms",
       "to": "+78122128506"
+    },
+    {
+      "type": "telegram",
+      "token": "1234567890:AAHG7MAKsUHLs-pBLhpIw1RU07Hmw9LyDac",
+      "chatId": "123456789"
     }
   ],
   "alarms": [

--- a/wbrules/alarms2.conf
+++ b/wbrules/alarms2.conf
@@ -15,6 +15,11 @@
     {
       "type": "sms",
       "to": "+78122128506"
+    },
+    {
+      "type": "telegram",
+      "token": "1234567890:AAHG7MAKsUHLs-pBLhpIw1RU07Hmw9LyDac",
+      "chatId": "123456789"
     }
   ],
   "alarms": [

--- a/wbrules/rule_alarm_test.go
+++ b/wbrules/rule_alarm_test.go
@@ -117,6 +117,7 @@ func (s *AlarmSuite) verifyNotificationMsgs(alarm string, text string, stopTimer
 		fmt.Sprintf("[info] EMAIL TO: someone@example.com SUBJ: alarm! TEXT: %s", text),
 		fmt.Sprintf("[info] EMAIL TO: anotherone@example.com SUBJ: Alarm: %s TEXT: %s", text, text),
 		fmt.Sprintf("[info] SMS TO: +78122128506 TEXT: %s", text),
+		fmt.Sprintf("[info] TELEGRAM MESSAGE TOKEN: 1234567890:AAHG7MAKsUHLs-pBLhpIw1RU07Hmw9LyDac CHATID: 123456789 TEXT: %s", text),
 	)
 }
 

--- a/wbrules/testrules_alarm.js
+++ b/wbrules/testrules_alarm.js
@@ -7,4 +7,8 @@ global.__proto__.Notify = {
   sendSMS: function sendSMS(to, text) {
     log('SMS TO: {} TEXT: {}', to, text);
   },
+
+  sendTelegramMessage: function sendTelegramMessage(token, chatId, text) {
+    log("TELEGRAM MESSAGE TOKEN: {} CHATID: {} TEXT: {}", token, chatId, text);
+  },
 };


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Ребейз старого пиара https://github.com/wirenboard/wb-rules/pull/55 + добавлены переводы, поправлена поддержка емодзи в сообщениях, тесты, обработка ошибок.

___________________________________
**Что поменялось для пользователей:**
1. В рулсах появился метод `Notify.sendTelegramMessage`:
```js
var msg = '⚠️ Line 1\n✅ Строка 2\n💧 Line 3';

Notify.sendTelegramMessage("<token>", "<chat id>", msg);
```
2. В настройках алармов можно настроить отправку в телегу:
![Screen Shot 2025-07-01 at 16 25 56](https://github.com/user-attachments/assets/285002fe-3978-4dda-87c8-413287892cfe)
![Screen Shot 2025-07-01 at 16 26 21](https://github.com/user-attachments/assets/0b51af6c-4c1a-40d5-96b0-d187c892996f)

Результат в тг:
![Screen Shot 2025-07-01 at 17 09 34](https://github.com/user-attachments/assets/a09fa20c-cf4a-4b60-b19c-4554efb0df4d)

___________________________________
**Как проверял/а:**
на контроллере