### PR TITLE
Alarms schema: add alarm name validation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.34.2) stable; urgency=medium
+
+  * Alarms schema: add alarm name validation
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 29 Jul 2025 23:00:00 +0400
+
 wb-rules (2.34.1) stable; urgency=medium
 
   * setInterval/startTicker: warn about too low interval

--- a/rules/alarms.schema.json
+++ b/rules/alarms.schema.json
@@ -99,8 +99,13 @@
                 "name": {
                     "type": "string",
                     "title": "Alarm name",
+                    "description": "Used as part of the topic",
+                    "pattern": "^[^$#+\\/]+$",
                     "minLength": 1,
-                    "propertyOrder": 1
+                    "propertyOrder": 1,
+                    "options": {
+                        "patternmessage": "Invalid alarm name"
+                    }
                 },
                 "cell": {
                     "type": "string",
@@ -418,7 +423,9 @@
             "Alarms": "Уведомления",
             "Alarm{{: |self.name}}": "Уведомление{{: |self.name}}",
             "Invalid format": "Неверный формат",
-            "Invalid device name": "Неверное имя устройства"
+            "Invalid device name": "Неверное имя устройства",
+            "Used as part of the topic": "Используется как часть топика в MQTT",
+            "Invalid alarm name": "Неверное название уведомления"
         }
     }
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Нигде не было указано что название уведомления используется как часть mqtt топика (имени контрола) и пользователи вводят туда произвольный текст. В случае использования недопустимых символов весь девайс алармов пропадает без внятной ошибки при сохранении конфига. Причину можно увидеть только в журнале или дебаг консоли:
```
2025-07-30 01:22:53 Error: Control ID is incorrect
	/_/github.com/wirenboard/go-duktape@v0.0.0-20240729075045-b4150233e350/api.go:124
	anon  native strict preventsyield
	doLoad /usr/share/wb-rules-system/scripts/lib.js:787 tailcalled
	F /usr/share/wb-rules/load_alarms.js:1 preventsyield
```

Добавил явное описание и проверку на этапе ввода названия:
<img width="569" height="242" alt="Screen Shot 2025-07-30 at 01 40 19" src="https://github.com/user-attachments/assets/108a7362-e6e5-4e3f-add3-f455dbb1ae57" />

___________________________________
**Что поменялось для пользователей:**
UI не позволит сохранить конфиг с невалидным именем аларма.

___________________________________
**Как проверял/а:**
на вб

