### PR TITLE
Add RPC method Rename

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.35.0) stable; urgency=medium
+
+  * Add RPC method Rename
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 08 Aug 2025 12:40:00 +0400
+
 wb-rules (2.34.3) stable; urgency=medium
 
   * Remove sensitive data from log

--- a/wbrules/editor.go
+++ b/wbrules/editor.go
@@ -78,7 +78,7 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorSaveResponse) erro
 
 	if !strings.HasSuffix(pth, ".js") {
 		return invalidExtensionError
-	} else if len(args.Path)+len(".js") > 255 {
+	} else if len(pth)+len(".js") > 255 {
 		return invalidLenError
 	}
 
@@ -209,12 +209,24 @@ type EditorRenameArgs struct {
 }
 
 func (editor *Editor) Rename(args *EditorRenameArgs, reply *bool) error {
+	newPath := path.Clean(args.NewPath)
+
+	for strings.HasPrefix(newPath, "/") {
+		newPath = newPath[1:]
+	}
+
+	if !strings.HasSuffix(newPath, ".js") {
+		return invalidExtensionError
+	} else if len(newPath)+len(".js") > 255 {
+		return invalidLenError
+	}
+
 	entry, err := editor.locateFile(args.Path)
 	if err != nil {
 		return err
 	}
 
-	newPath := strings.Replace(entry.PhysicalPath, entry.VirtualPath, args.NewPath, 1)
+	newPath = strings.Replace(entry.PhysicalPath, entry.VirtualPath, newPath, 1)
 
 	if _, err = os.Stat(newPath); !os.IsNotExist(err) {
 		wbgong.Error.Printf("can't rename %s to %s: looks like second file exists already, deal with this by yourself!",

--- a/wbrules/editor_test.go
+++ b/wbrules/editor_test.go
@@ -36,7 +36,7 @@ func (s *EditorSuite) SetupTest() {
 	s.RpcFixture = testutils.NewRpcFixture(
 		s.T(), "wbrules", "Editor", "wbrules",
 		NewEditor(s),
-		"ChangeState", "List", "Load", "Remove", "Save")
+		"ChangeState", "List", "Load", "Remove", "Rename", "Save")
 }
 
 func (s *EditorSuite) TearDownTest() {
@@ -369,6 +369,27 @@ func (s *EditorSuite) TestEnableDisableFile() {
 		EDITOR_ERROR_OVERWRITE, "EditorError", "New-state file already exists")
 
 	s.EnsureGotErrors()
+}
+
+func (s *EditorSuite) TestRenameFile() {
+	s.VerifyRpc("Rename", objx.Map{"path": "sample1.js", "new_path": "sample1_new.js"}, true)
+	s.verifySources(map[string]string{
+		"sample1_new.js":      "// sample1",
+		"sample2.js":          "// sample2",
+		"sample3.js.disabled": "// disabled sample3",
+	})
+	s.VerifyRpc("ChangeState", objx.Map{"path": "sample1_new.js", "state": false}, true)
+	s.verifySources(map[string]string{
+		"sample1_new.js.disabled": "// sample1",
+		"sample2.js":              "// sample2",
+		"sample3.js.disabled":     "// disabled sample3",
+	})
+	s.VerifyRpc("Rename", objx.Map{"path": "sample1_new.js", "new_path": "sample1.js"}, true)
+	s.verifySources(map[string]string{
+		"sample1.js.disabled": "// sample1",
+		"sample2.js":          "// sample2",
+		"sample3.js.disabled": "// disabled sample3",
+	})
 }
 
 func TestEditorSuite(t *testing.T) {

--- a/wbrules/editor_test.go
+++ b/wbrules/editor_test.go
@@ -372,6 +372,16 @@ func (s *EditorSuite) TestEnableDisableFile() {
 }
 
 func (s *EditorSuite) TestRenameFile() {
+	s.VerifyRpcError("Rename", objx.Map{"path": "sample1.js", "new_path": "sample2.js"},
+		EDITOR_ERROR_OVERWRITE, "EditorError", "New-state file already exists")
+	s.VerifyRpcError("Rename", objx.Map{"path": "sample1.js", "new_path": "sample1_new"},
+		EDITOR_ERROR_INVALID_EXT, "EditorError", "File name should ends with .js")
+	s.VerifyRpcError("Rename", objx.Map{"path": "sample1.js", "new_path": strings.Repeat("x", 255) + ".js"},
+		EDITOR_ERROR_INVALID_LEN, "EditorError", "File path should be shorter than or equal to 255 chars")
+	s.VerifyRpcError("Rename", objx.Map{"path": "nosuchfile.js", "new_path": "sample1_new.js"},
+		EDITOR_ERROR_FILE_NOT_FOUND, "EditorError", "File not found")
+	s.EnsureGotErrors()
+
 	s.VerifyRpc("Rename", objx.Map{"path": "sample1.js", "new_path": "sample1_new.js"}, true)
 	s.verifySources(map[string]string{
 		"sample1_new.js":      "// sample1",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сейчас при переименовании фронт сохраняет правило под новым именем (вызов Save RPC), затем удаляет старое (вызов Remove RPC), см. https://github.com/wirenboard/homeui/blob/25cef3edba103d33d9fc5e9229744dda24fc5e52/frontend/src/pages/rules/%5Brule%5D/edit-rule.tsx#L49.
С этим есть ряд проблем:
* при сохранении получаем ошибку, что такой девайс уже существует, так как в момент сохранения исходный скрипт еще не удален
* переименование выключенного правила приводит к его включению, так как Save метод не знает ничего о статусе

Поэтому лучше облегчить задачу фронту и добавить отдельный метод Rename.
___________________________________
**Что поменялось для пользователей:**
ничего, нужна еще правка в homeui, чтобы использовал новый Rename метод.

___________________________________
**Как проверял/а:**
```sh
# mqtt-rpc-client -d wbrules -s Editor -m Save -a '{"path":"test.js","content":"//test"}'
{"path": "test.js"}
# mqtt-rpc-client -d wbrules -s Editor -m Rename -a '{"path":"test.js","new_path":"test_new.js"}'
true
# cat /etc/wb-rules/test_new.js
//test
# mqtt-rpc-client -d wbrules -s Editor -m ChangeState -a '{"path":"test_new.js","state":false}'
true
# cat /etc/wb-rules/test_new.js.disabled
//test
# mqtt-rpc-client -d wbrules -s Editor -m Rename -a '{"path":"test_new.js","new_path":"test.js"}'
true
# cat /etc/wb-rules/test.js.disabled
//test
```
