### PR TITLE
RPC: Load: fix error message

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.35.2) stable; urgency=medium
+
+  * RPC: Load: fix error message
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 14 Aug 2025 18:00:00 +0400
+
 wb-rules (2.35.1) stable; urgency=medium
 
   * Don't wait for token on topics cleanup, update wbgo.so library

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ const (
 	DRIVER_CONV_ID   = "wb-rules"
 	ENGINE_CLIENT_ID = "wb-rules-engine"
 
+	RPC_DRIVER_NAME = "wbrules"
+
 	PERSISTENT_DB_FILE      = "/var/lib/wirenboard/wbrules-persistent.db"
 	VIRTUAL_DEVICES_DB_FILE = "/var/lib/wirenboard/wbrules-vdev.db"
 	WBGO_FILE               = "/usr/lib/wb-rules/wbgo.so"
@@ -174,7 +176,7 @@ func main() {
 	wbgong.Info.Println("all rule files are loaded")
 
 	if *editDir != "" {
-		rpc := wbgong.NewMQTTRPCServer("wbrules", engineMqttClient)
+		rpc := wbgong.NewMQTTRPCServer(RPC_DRIVER_NAME, engineMqttClient)
 		rpc.Register(wbrules.NewEditor(engine))
 		rpc.Start()
 		defer rpc.Stop()

--- a/wbrules/editor.go
+++ b/wbrules/editor.go
@@ -43,6 +43,7 @@ const (
 var invalidExtensionError = &EditorError{EDITOR_ERROR_INVALID_EXT, "File name should ends with .js"}
 var invalidLenError = &EditorError{EDITOR_ERROR_INVALID_LEN, "File path should be shorter than or equal to 255 chars"}
 var listDirError = &EditorError{EDITOR_ERROR_LISTDIR, "Error listing the directory"}
+var readError = &EditorError{EDITOR_ERROR_WRITE, "Error reading the file"}
 var writeError = &EditorError{EDITOR_ERROR_WRITE, "Error writing the file"}
 var fileNotFoundError = &EditorError{EDITOR_ERROR_FILE_NOT_FOUND, "File not found"}
 var rmError = &EditorError{EDITOR_ERROR_REMOVE, "Error removing the file"}
@@ -150,7 +151,7 @@ func (editor *Editor) Load(args *EditorPathArgs, reply *EditorContentResponse) e
 	content, err := os.ReadFile(entry.PhysicalPath)
 	if err != nil {
 		wbgong.Error.Printf("error reading %s: %s", entry.PhysicalPath, err)
-		return writeError
+		return readError
 	}
 	*reply = EditorContentResponse{
 		string(content),

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -914,6 +914,7 @@ func (engine *ESEngine) LiveWriteScript(virtualPath, content string) error {
 // ready. If the script didn't change since the last time it was loaded,
 // the script isn't loaded.
 func (engine *ESEngine) LiveLoadFile(path string) error {
+	wbgong.Debug.Printf("LiveLoadFile: %s", path)
 	r := make(chan error)
 	engine.WhenEngineReady(func() {
 		r <- engine.loadScriptAndRefresh(path, false)
@@ -923,7 +924,7 @@ func (engine *ESEngine) LiveLoadFile(path string) error {
 }
 
 func (engine *ESEngine) LiveRemoveFile(path string) error {
-	wbgong.Info.Printf("LiveRemoveFile: %s", path)
+	wbgong.Debug.Printf("LiveRemoveFile: %s", path)
 	path, virtualPath, _, _, err := engine.checkSourcePath(path)
 
 	if err != nil {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При ошибке чтения скрипта возвращает `Error writing the file`:
```sh
/rpc/v1/wbrules/Editor/Load/15898 {"id":1,"params":{"path":"test.js"}}
/rpc/v1/wbrules/Editor/Load/15898/reply {"error":{"code":1002,"data":"EditorError","message":"Error writing the file"},"id":1}
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на вб

