### PR TITLE
Добавить Node.js-style файловый API (глобальный объект fs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Rule engine for Wiren Board, version 2.0
 - [Доступ к топикам meta](#доступ-к-топикам-meta)
 - [API создания/управления устройств](#api-созданияуправления-устройств)
 - [Встроенные функции и переменные](#встроенные-функции-и-переменные)
+- [Файловые операции `fs`](#файловые-операции-fs)
 - [Модули](#модули)
 - [Сервис оповещений](#сервис-оповещений)
 - [Сервис алармов](#сервис-алармов)
@@ -863,6 +864,367 @@ $ cat test.conf
   ]
 }
 ```
+
+## Файловые операции `fs`
+
+Глобальный объект `fs` предоставляет функции для работы с файловой системой, следующие конвенции Node.js:
+- **Синхронные** функции имеют суффикс `Sync` (например, `fs.readFileSync()`). Они блокируют выполнение и возвращают результат напрямую (или генерируют исключение при ошибке).
+- **Асинхронные** функции (без суффикса) принимают callback последним аргументом и выполняют I/O в фоне. Callback вызывается по паттерну error-first: `callback(err, data)`, где `err` — объект `{message: "..."}` при ошибке или `null` при успехе.
+
+Функции работают только с текстовыми (UTF-8) данными. Бинарные файлы не поддерживаются.
+
+**Важно:** объект `fs` имеет неограниченный доступ к файловой системе с правами процесса wb-rules. Пользовательские скрипты могут читать, писать и удалять любые доступные файлы.
+
+#### Отличия от Node.js API
+
+- `statSync()` / `stat()` возвращают объект со **свойствами** `isFile`, `isDirectory` (а не методами `isFile()`, `isDirectory()` как в Node.js)
+- `readdirSync()` / `readdir()` всегда возвращают массив объектов `{name, isFile, isDirectory}` (в Node.js по умолчанию возвращаются строки, объекты — только с опцией `{withFileTypes: true}`)
+- `stat.mode` — строка в восьмеричном формате (например, `"644"`), а не числовая битовая маска
+- Объекты ошибок содержат только поле `message` (без `code`, `errno`, `path`, `syscall`)
+- Нет поддержки Buffer/encoding — только строки UTF-8
+- `writeFileSync()` создаёт файл с правами `0644` (при перезаписи существующего файла его права сохраняются), без параметра options
+- Максимальный размер файла для `readFileSync` / `readFile` — 10 МБ
+
+### Синхронные функции
+
+#### `fs.readFileSync(path)`
+
+Читает содержимое файла и возвращает его как строку. Максимальный размер файла — 10 МБ.
+
+```js
+var content = fs.readFileSync("/etc/hostname");
+log("hostname: {}", content);
+```
+
+#### `fs.writeFileSync(path, data)`
+
+Записывает строку в файл, создавая файл при необходимости или перезаписывая существующий. Запись атомарна (через временный файл + rename), поэтому файл не будет повреждён при внезапном отключении питания. При создании нового файла устанавливаются права `0644`; при перезаписи существующего файла его права не изменяются.
+
+```js
+fs.writeFileSync("/tmp/output.txt", "hello world");
+```
+
+#### `fs.appendFileSync(path, data)`
+
+Дописывает строку в конец файла. Если файл не существует, создаёт его с правами `0644`.
+
+```js
+fs.appendFileSync("/tmp/log.txt", "new line\n");
+```
+
+#### `fs.statSync(path)`
+
+Возвращает информацию о файле или директории в виде объекта:
+- `size` — размер в байтах
+- `isFile` — `true`, если это обычный файл
+- `isDirectory` — `true`, если это директория
+- `mtime` — время последней модификации (Unix timestamp)
+- `mode` — права доступа в восьмеричном формате (строка, например `"644"`)
+
+```js
+var st = fs.statSync("/etc/hostname");
+log("size={} isFile={}", st.size, st.isFile);
+```
+
+#### `fs.readdirSync(path)`
+
+Возвращает массив объектов с информацией о содержимом директории. Каждый элемент содержит:
+- `name` — имя файла или директории
+- `isFile` — `true`, если это обычный файл
+- `isDirectory` — `true`, если это директория
+
+```js
+var entries = fs.readdirSync("/tmp");
+for (var i = 0; i < entries.length; i++) {
+  log("{} (file={})", entries[i].name, entries[i].isFile);
+}
+```
+
+#### `fs.existsSync(path)`
+
+Возвращает `true`, если файл или директория существует, `false` в противном случае. В отличие от остальных функций, **не генерирует исключение** при отсутствии файла.
+
+```js
+if (fs.existsSync("/tmp/flag.txt")) {
+  log("file exists");
+}
+```
+
+#### `fs.mkdirSync(path [, options])`
+
+Создаёт директорию с правами `0755`. Для создания вложенных директорий используйте опцию `{recursive: true}`.
+
+```js
+fs.mkdirSync("/tmp/newdir");
+fs.mkdirSync("/tmp/a/b/c", {recursive: true});
+```
+
+#### `fs.unlinkSync(path)`
+
+Удаляет файл. Для удаления директорий используйте `fs.rmdirSync()`.
+
+```js
+fs.unlinkSync("/tmp/output.txt");
+```
+
+#### `fs.renameSync(oldPath, newPath)`
+
+Переименовывает или перемещает файл.
+
+```js
+fs.renameSync("/tmp/old.txt", "/tmp/new.txt");
+```
+
+#### `fs.rmdirSync(path [, options])`
+
+Удаляет директорию. По умолчанию директория должна быть пустой. Для рекурсивного удаления используйте опцию `{recursive: true}`.
+
+```js
+fs.rmdirSync("/tmp/emptydir");
+fs.rmdirSync("/tmp/dir_with_files", {recursive: true});
+```
+
+#### `fs.copyFileSync(src, dest)`
+
+Копирует файл из `src` в `dest`. Права доступа исходного файла сохраняются.
+
+```js
+fs.copyFileSync("/tmp/source.txt", "/tmp/dest.txt");
+```
+
+#### `fs.accessSync(path [, mode])`
+
+Проверяет доступность файла. Если файл недоступен — генерирует исключение. Аргумент `mode` (по умолчанию `fs.constants.F_OK`) определяет тип проверки. Константы доступны через `fs.constants`:
+
+| Константа | Значение | Описание |
+|-----------|----------|----------|
+| `fs.constants.F_OK` | 0 | Файл существует |
+| `fs.constants.R_OK` | 4 | Файл доступен для чтения |
+| `fs.constants.W_OK` | 2 | Файл доступен для записи |
+| `fs.constants.X_OK` | 1 | Файл доступен для выполнения |
+
+```js
+// Проверить существование
+fs.accessSync("/tmp/file.txt");
+
+// Проверить права на чтение и запись
+fs.accessSync("/tmp/file.txt", fs.constants.R_OK | fs.constants.W_OK);
+```
+
+#### `fs.realpathSync(path)`
+
+Разрешает все символические ссылки в пути и возвращает абсолютный путь.
+
+```js
+var realPath = fs.realpathSync("/tmp/symlink");
+log("real path: {}", realPath);
+```
+
+#### `fs.readlinkSync(path)`
+
+Читает цель символической ссылки и возвращает путь, на который она указывает.
+
+```js
+var target = fs.readlinkSync("/tmp/symlink");
+log("link target: {}", target);
+```
+
+#### Обработка ошибок (sync)
+
+Все синхронные функции `fs` (кроме `fs.existsSync()`) генерируют исключение при ошибке. Для обработки ошибок используйте `try/catch`:
+
+```js
+try {
+  var content = fs.readFileSync("/nonexistent/file");
+} catch (e) {
+  log.error("failed to read file: {}", e.message);
+}
+```
+
+### Асинхронные функции
+
+Асинхронные версии выполняют I/O в фоновом потоке и вызывают callback по завершению. Callback следует паттерну error-first: первый аргумент — ошибка (`null` при успехе, объект `{message: "..."}` при ошибке), второй — результат.
+
+#### `fs.readFile(path, callback)`
+
+```js
+fs.readFile("/etc/hostname", function (err, data) {
+  if (err) {
+    log.error("failed: {}", err.message);
+    return;
+  }
+  log("hostname: {}", data);
+});
+```
+
+#### `fs.writeFile(path, data, callback)`
+
+```js
+fs.writeFile("/tmp/output.txt", "hello world", function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+```
+
+#### `fs.appendFile(path, data, callback)`
+
+```js
+fs.appendFile("/tmp/log.txt", "new line\n", function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+```
+
+#### `fs.stat(path, callback)`
+
+```js
+fs.stat("/etc/hostname", function (err, st) {
+  if (err) {
+    log.error("failed: {}", err.message);
+    return;
+  }
+  log("size={} isFile={}", st.size, st.isFile);
+});
+```
+
+#### `fs.readdir(path, callback)`
+
+```js
+fs.readdir("/tmp", function (err, entries) {
+  if (err) {
+    log.error("failed: {}", err.message);
+    return;
+  }
+  for (var i = 0; i < entries.length; i++) {
+    log("{} (file={})", entries[i].name, entries[i].isFile);
+  }
+});
+```
+
+#### `fs.exists(path, callback)`
+
+**Внимание:** в отличие от остальных async-функций, callback получает один аргумент `exists` (boolean), без `err`. Это соответствует конвенции Node.js.
+
+```js
+fs.exists("/tmp/flag.txt", function (exists) {
+  if (exists) {
+    log("file exists");
+  }
+});
+```
+
+#### `fs.mkdir(path [, options], callback)`
+
+```js
+fs.mkdir("/tmp/newdir", function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+
+fs.mkdir("/tmp/a/b/c", {recursive: true}, function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+```
+
+#### `fs.unlink(path, callback)`
+
+```js
+fs.unlink("/tmp/output.txt", function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+```
+
+#### `fs.rename(oldPath, newPath, callback)`
+
+```js
+fs.rename("/tmp/old.txt", "/tmp/new.txt", function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+```
+
+#### `fs.rmdir(path [, options], callback)`
+
+```js
+fs.rmdir("/tmp/emptydir", function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+
+fs.rmdir("/tmp/dir_with_files", {recursive: true}, function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+```
+
+#### `fs.copyFile(src, dest, callback)`
+
+```js
+fs.copyFile("/tmp/source.txt", "/tmp/dest.txt", function (err) {
+  if (err) {
+    log.error("failed: {}", err.message);
+  }
+});
+```
+
+#### `fs.access(path [, mode], callback)`
+
+```js
+fs.access("/tmp/file.txt", fs.constants.R_OK, function (err) {
+  if (err) {
+    log.error("file is not readable: {}", err.message);
+  }
+});
+```
+
+#### `fs.realpath(path, callback)`
+
+```js
+fs.realpath("/tmp/symlink", function (err, resolvedPath) {
+  if (err) {
+    log.error("failed: {}", err.message);
+    return;
+  }
+  log("real path: {}", resolvedPath);
+});
+```
+
+#### `fs.readlink(path, callback)`
+
+```js
+fs.readlink("/tmp/symlink", function (err, target) {
+  if (err) {
+    log.error("failed: {}", err.message);
+    return;
+  }
+  log("link target: {}", target);
+});
+```
+
+#### `fs.watch(path, callback)`
+
+Отслеживает изменения файла. Возвращает объект с методом `close()` для остановки наблюдения. Callback вызывается при каждом изменении с аргументами `(eventType, filename)`, где `eventType` — `"change"` (запись, изменение атрибутов) или `"rename"` (создание, удаление, переименование).
+
+```js
+var watcher = fs.watch("/tmp/config.txt", function (eventType, filename) {
+  log("file {} event: {}", filename, eventType);
+});
+
+// Позже, для остановки наблюдения:
+watcher.close();
+```
+
+**Внимание:** наблюдатель автоматически закрывается при перезагрузке скрипта.
 
 ### Алиасы `defineAlias()`
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.38.7) UNRELEASED; urgency=medium
+
+  * Add Node.js-style filesystem API (global fs object)
+
+ -- Evgeny Boger <boger@wirenboard.com>  Sun, 01 Mar 2026 15:36:00 +0300
+
 wb-rules (2.38.6) stable; urgency=medium
 
   * Fix crash on calling method of removed control

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7
 	github.com/VictoriaMetrics/metrics v1.37.0
 	github.com/boltdb/bolt v0.0.0-20161223174454-2e25e3bb4285
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.0
@@ -18,6 +19,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/valyala/fastrand v1.1.0 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/boltdb/bolt v0.0.0-20161223174454-2e25e3bb4285/go.mod h1:clJnj/oiGkju
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
@@ -25,8 +27,8 @@ github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350 h1:hjfTrSlSU
 github.com/wirenboard/go-duktape v0.0.0-20240729075045-b4150233e350/go.mod h1:RBaIu9caMBuL6Xk32Ty04qAjl/5cVSfEdCQtbWzvMQ0=
 github.com/wirenboard/wbgong v0.6.0 h1:DjUUditytuvQYnRWvXk+LrOkMC4YToLK1+QzZO74ojc=
 github.com/wirenboard/wbgong v0.6.0/go.mod h1:FeSukEiXj10SVQ6x4UPoW3O5P/KTRkAWKvEbo9Ftdug=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/wbrules/escontext.go
+++ b/wbrules/escontext.go
@@ -29,6 +29,7 @@ type ESLocation struct {
 type ESTraceback []ESLocation
 type ESCallback uint64
 type ESCallbackFunc func(args objx.Map) interface{}
+type ESCallbackArgsFunc func(args ...interface{})
 type ESCallbackErrorHandler func(err ESError)
 
 // ESSyncFunc denotes a function that executes the specified
@@ -376,6 +377,41 @@ func (ctx *ESContext) WrapCallback(callbackStackIndex int) ESCallbackFunc {
 	runtime.SetFinalizer(holder, callbackFinalizer)
 	return func(args objx.Map) interface{} {
 		return ctx.invokeCallback(holder.callback, args)
+	}
+}
+
+// WrapCallbackArgs is like WrapCallback but returns a function that accepts
+// multiple positional arguments, suitable for Node.js error-first callbacks.
+func (ctx *ESContext) WrapCallbackArgs(callbackStackIndex int) ESCallbackArgsFunc {
+	holder := &callbackHolder{
+		ctx,
+		ctx.storeCallback(callbackStackIndex),
+	}
+	runtime.SetFinalizer(holder, callbackFinalizer)
+	return func(args ...interface{}) {
+		ctx.invokeCallbackArgs(holder.callback, args...)
+	}
+}
+
+// invokeCallbackArgs calls the stored callback with multiple positional arguments.
+func (ctx *ESContext) invokeCallbackArgs(key ESCallback, args ...interface{}) {
+	ctx.mustBeValid()
+
+	ctx.PushHeapStash()
+	ctx.GetPropString(-1, ESCALLBACKS_OBJ_NAME)
+	ctx.PushString(ctx.callbackKey(key))
+	for _, arg := range args {
+		if arg == nil {
+			ctx.PushNull()
+		} else {
+			ctx.PushJSObject(arg)
+		}
+	}
+	// PcallProp consumes key + all args and pushes one result,
+	// so the stack always has exactly 3 items to pop: result, callbacksObj, heapStash.
+	defer ctx.Pop3()
+	if s := ctx.PcallProp(-2-len(args), len(args)); s != 0 {
+		ctx.callbackErrorHandler(ctx.GetESError())
 	}
 }
 

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -214,6 +214,54 @@ func NewESEngine(driver wbgong.Driver, logMqttClient wbgong.MQTTClient, options 
 	})
 	engine.globalCtx.Pop()
 
+	// Register fs object with filesystem functions
+	engine.globalCtx.PushObject()
+	engine.globalCtx.DefineFunctions(map[string]func(*ESContext) int{
+		// Sync functions (Node.js *Sync convention)
+		"readFileSync":   engine.esFileReadFileSync,
+		"writeFileSync":  engine.esFileWriteFileSync,
+		"appendFileSync": engine.esFileAppendFileSync,
+		"statSync":       engine.esFileStatSync,
+		"readdirSync":    engine.esFileReaddirSync,
+		"existsSync":     engine.esFileExistsSync,
+		"mkdirSync":      engine.esFileMkdirSync,
+		"unlinkSync":     engine.esFileUnlinkSync,
+		"renameSync":     engine.esFileRenameSync,
+		"rmdirSync":      engine.esFileRmdirSync,
+		"copyFileSync":   engine.esFileCopyFileSync,
+		"accessSync":     engine.esFileAccessSync,
+		"realpathSync":   engine.esFileRealpathSync,
+		"readlinkSync":   engine.esFileReadlinkSync,
+		// Async functions (error-first callback)
+		"readFile":   engine.esFileReadFile,
+		"writeFile":  engine.esFileWriteFile,
+		"appendFile": engine.esFileAppendFile,
+		"stat":       engine.esFileStat,
+		"readdir":    engine.esFileReaddir,
+		"exists":     engine.esFileExists,
+		"mkdir":      engine.esFileMkdir,
+		"unlink":     engine.esFileUnlink,
+		"rename":     engine.esFileRename,
+		"rmdir":      engine.esFileRmdir,
+		"copyFile":   engine.esFileCopyFile,
+		"access":     engine.esFileAccess,
+		"realpath":   engine.esFileRealpath,
+		"readlink":   engine.esFileReadlink,
+		"watch":      engine.esFileWatch,
+	})
+	// Access mode constants (match Node.js fs.constants)
+	engine.globalCtx.PushObject() // constants sub-object
+	engine.globalCtx.PushInt(0)   // F_OK
+	engine.globalCtx.PutPropString(-2, "F_OK")
+	engine.globalCtx.PushInt(1) // X_OK
+	engine.globalCtx.PutPropString(-2, "X_OK")
+	engine.globalCtx.PushInt(2) // W_OK
+	engine.globalCtx.PutPropString(-2, "W_OK")
+	engine.globalCtx.PushInt(4) // R_OK
+	engine.globalCtx.PutPropString(-2, "R_OK")
+	engine.globalCtx.PutPropString(-2, "constants") // fs.constants = {F_OK, X_OK, W_OK, R_OK}
+	engine.globalCtx.PutPropString(-2, "fs")
+
 	// set global prototype to __wbModulePrototype
 	engine.globalCtx.GetPropString(-1, MODULE_OBJ_PROTO_NAME)
 	engine.globalCtx.SetPrototype(-2)

--- a/wbrules/esengine_fileio.go
+++ b/wbrules/esengine_fileio.go
@@ -1,0 +1,1065 @@
+package wbrules
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/fsnotify/fsnotify"
+	duktape "github.com/wirenboard/go-duktape"
+	"github.com/wirenboard/wbgong"
+)
+
+const maxReadFileSize = 10 * 1024 * 1024 // 10 MB
+
+// fsAsyncCallbackPreamble checks ctx validity and pushes cleanup scope inside CallSync.
+// Returns ("", false) if context is no longer valid (caller should return).
+// On success returns (filename, true); the caller must defer fsAsyncCallbackPostamble(filename).
+func (engine *ESEngine) fsAsyncCallbackPreamble(ctx *ESContext) (string, bool) {
+	if !ctx.IsValid() {
+		wbgong.Info.Println("ignore fs callback without Duktape context (maybe script is reloaded or removed)")
+		return "", false
+	}
+
+	filename := ctx.GetCurrentFilename()
+	if filename != "" {
+		engine.cleanup.PushCleanupScope(filename)
+	}
+	return filename, true
+}
+
+func (engine *ESEngine) fsAsyncCallbackPostamble(filename string) {
+	if filename != "" {
+		engine.cleanup.PopCleanupScope(filename)
+	}
+}
+
+func fsErrObj(err error) map[string]any {
+	return map[string]any{"message": err.Error()}
+}
+
+// fsAsyncCallback is a helper that wraps the common CallSync + preamble/postamble + error-first
+// callback pattern used by all async fs functions (except fs.exists and fs.watch).
+// If err != nil, callback receives (errObj, nil, nil, ...) with nils matching the count of results.
+// If err == nil, callback receives (nil, results...).
+func (engine *ESEngine) fsAsyncCallback(ctx *ESContext, callbackFn func(...any), err error, results ...any) {
+	engine.CallSync(func() {
+		filename, ok := engine.fsAsyncCallbackPreamble(ctx)
+		if !ok {
+			return
+		}
+		defer engine.fsAsyncCallbackPostamble(filename)
+
+		if err != nil {
+			args := make([]any, 1+len(results))
+			args[0] = fsErrObj(err)
+			callbackFn(args...)
+		} else {
+			args := make([]any, 1+len(results))
+			args[0] = nil
+			copy(args[1:], results)
+			callbackFn(args...)
+		}
+	})
+}
+
+func buildStatObj(info os.FileInfo) map[string]any {
+	return map[string]any{
+		"size":        info.Size(),
+		"isFile":      info.Mode().IsRegular(),
+		"isDirectory": info.IsDir(),
+		"mtime":       info.ModTime().Unix(),
+		"mode":        fmt.Sprintf("%o", info.Mode().Perm()),
+	}
+}
+
+func buildDirEntry(name string, info os.FileInfo) map[string]any {
+	return map[string]any{
+		"name":        name,
+		"isFile":      info.Mode().IsRegular(),
+		"isDirectory": info.IsDir(),
+	}
+}
+
+// ──────────────────────────────────────────────
+// Sync functions
+// ──────────────────────────────────────────────
+
+// fs.readFileSync(path) -> string
+func (engine *ESEngine) esFileReadFileSync(ctx *ESContext) int {
+	if ctx.GetTop() != 1 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.readFileSync(): expected (path)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+
+	f, err := os.Open(path)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.readFileSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxReadFileSize+1))
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.readFileSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+	if int64(len(data)) > maxReadFileSize {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.readFileSync() failed: file %s is too large (max %d bytes)", path, maxReadFileSize))
+		return duktape.DUK_RET_ERROR
+	}
+
+	ctx.PushString(string(data))
+	return 1
+}
+
+// atomicWriteFile writes data to path atomically via temp file + rename.
+// This ensures the file is never left in a partially-written state on power loss.
+// If the target file already exists, its permissions are preserved.
+func atomicWriteFile(path string, data []byte, defaultPerm os.FileMode) error {
+	// Preserve existing file permissions if the file already exists
+	perm := defaultPerm
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
+
+	dir := filepath.Dir(path)
+
+	// Verify the target directory exists before creating temp file,
+	// so error messages reference the original path, not the temp file
+	if _, err := os.Stat(dir); err != nil {
+		pathErr := &os.PathError{Op: "open", Path: path}
+		var pe *os.PathError
+		if errors.As(err, &pe) {
+			pathErr.Err = pe.Err
+		} else {
+			pathErr.Err = err
+		}
+		return pathErr
+	}
+
+	tmp, err := os.CreateTemp(dir, ".wb-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+
+	_, writeErr := tmp.Write(data)
+	syncErr := tmp.Sync()
+	closeErr := tmp.Close()
+
+	if writeErr != nil {
+		os.Remove(tmpName)
+		return writeErr
+	}
+	if syncErr != nil {
+		os.Remove(tmpName)
+		return syncErr
+	}
+	if closeErr != nil {
+		os.Remove(tmpName)
+		return closeErr
+	}
+
+	if err := os.Chmod(tmpName, perm); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// fs.writeFileSync(path, data)
+func (engine *ESEngine) esFileWriteFileSync(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsString(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.writeFileSync(): expected (path, data)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	data := ctx.GetString(1)
+	if err := atomicWriteFile(path, []byte(data), 0o644); err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.writeFileSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.appendFileSync(path, data)
+func (engine *ESEngine) esFileAppendFileSync(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsString(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.appendFileSync(): expected (path, data)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	data := ctx.GetString(1)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.appendFileSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	_, writeErr := f.WriteString(data)
+	closeErr := f.Close()
+	if writeErr != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.appendFileSync() failed: %s", writeErr))
+		return duktape.DUK_RET_ERROR
+	}
+	if closeErr != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.appendFileSync() failed: %s", closeErr))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.statSync(path) -> {size, isFile, isDirectory, mtime, mode}
+func (engine *ESEngine) esFileStatSync(ctx *ESContext) int {
+	if ctx.GetTop() != 1 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.statSync(): expected (path)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	info, err := os.Stat(path)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.statSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	ctx.PushJSObject(buildStatObj(info))
+	return 1
+}
+
+// fs.readdirSync(path) -> [{name, isFile, isDirectory}, ...]
+func (engine *ESEngine) esFileReaddirSync(ctx *ESContext) int {
+	if ctx.GetTop() != 1 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.readdirSync(): expected (path)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.readdirSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	result := make([]any, len(entries))
+	for i, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.readdirSync() failed: %s", err))
+			return duktape.DUK_RET_ERROR
+		}
+		result[i] = buildDirEntry(entry.Name(), info)
+	}
+
+	ctx.PushJSObject(result)
+	return 1
+}
+
+// fs.existsSync(path) -> bool
+func (engine *ESEngine) esFileExistsSync(ctx *ESContext) int {
+	if ctx.GetTop() != 1 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.existsSync(): expected (path)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	_, err := os.Stat(path)
+	ctx.PushBoolean(err == nil)
+	return 1
+}
+
+// fs.mkdirSync(path [, {recursive: true}])
+func (engine *ESEngine) esFileMkdirSync(ctx *ESContext) int {
+	numArgs := ctx.GetTop()
+	if numArgs < 1 || numArgs > 2 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.mkdirSync(): expected (path [, {recursive}])")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	recursive := false
+
+	if numArgs == 2 && ctx.IsObject(1) {
+		ctx.GetPropString(1, "recursive")
+		if ctx.IsBoolean(-1) {
+			recursive = ctx.GetBoolean(-1)
+		}
+		ctx.Pop()
+	}
+
+	var err error
+	if recursive {
+		err = os.MkdirAll(path, 0o755)
+	} else {
+		err = os.Mkdir(path, 0o755)
+	}
+
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.mkdirSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.unlinkSync(path) — removes a file (not a directory)
+func (engine *ESEngine) esFileUnlinkSync(ctx *ESContext) int {
+	if ctx.GetTop() != 1 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.unlinkSync(): expected (path)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.unlinkSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+	if info.IsDir() {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.unlinkSync() failed: %s is a directory, use fs.rmdirSync() or remove manually", path))
+		return duktape.DUK_RET_ERROR
+	}
+
+	if err := os.Remove(path); err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.unlinkSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.renameSync(oldPath, newPath)
+func (engine *ESEngine) esFileRenameSync(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsString(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.renameSync(): expected (oldPath, newPath)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	oldPath := ctx.GetString(0)
+	newPath := ctx.GetString(1)
+	if err := os.Rename(oldPath, newPath); err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.renameSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.rmdirSync(path [, {recursive: true}])
+func (engine *ESEngine) esFileRmdirSync(ctx *ESContext) int {
+	numArgs := ctx.GetTop()
+	if numArgs < 1 || numArgs > 2 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.rmdirSync(): expected (path [, {recursive}])")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	recursive := false
+
+	if numArgs == 2 && ctx.IsObject(1) {
+		ctx.GetPropString(1, "recursive")
+		if ctx.IsBoolean(-1) {
+			recursive = ctx.GetBoolean(-1)
+		}
+		ctx.Pop()
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.rmdirSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+	if !info.IsDir() {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.rmdirSync() failed: %s is not a directory", path))
+		return duktape.DUK_RET_ERROR
+	}
+
+	if recursive {
+		cleanPath := filepath.Clean(path)
+		if cleanPath == "/" || cleanPath == "." {
+			engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.rmdirSync() failed: refusing to recursively remove %q", path))
+			return duktape.DUK_RET_ERROR
+		}
+		err = os.RemoveAll(path)
+	} else {
+		err = os.Remove(path)
+	}
+
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.rmdirSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.copyFileSync(src, dest)
+func (engine *ESEngine) esFileCopyFileSync(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsString(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.copyFileSync(): expected (src, dest)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	src := ctx.GetString(0)
+	dest := ctx.GetString(1)
+
+	// Guard against self-copy: use os.SameFile to handle symlinks and hard links
+	if srcInfo, err := os.Stat(src); err == nil {
+		if destInfo, err := os.Stat(dest); err == nil && os.SameFile(srcInfo, destInfo) {
+			return 0
+		}
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.copyFileSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+	defer srcFile.Close()
+
+	info, err := srcFile.Stat()
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.copyFileSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	destFile, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.copyFileSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	_, copyErr := io.Copy(destFile, srcFile)
+	closeErr := destFile.Close()
+	if copyErr != nil {
+		os.Remove(dest)
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.copyFileSync() failed: %s", copyErr))
+		return duktape.DUK_RET_ERROR
+	}
+	if closeErr != nil {
+		os.Remove(dest)
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.copyFileSync() failed: %s", closeErr))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.accessSync(path [, mode])
+func (engine *ESEngine) esFileAccessSync(ctx *ESContext) int {
+	numArgs := ctx.GetTop()
+	if numArgs < 1 || numArgs > 2 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.accessSync(): expected (path [, mode])")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	mode := uint32(syscall.F_OK)
+
+	if numArgs == 2 && ctx.IsNumber(1) {
+		mode = uint32(ctx.GetNumber(1))
+	}
+
+	if mode > 7 {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.accessSync() failed: invalid mode %d", mode))
+		return duktape.DUK_RET_ERROR
+	}
+
+	if err := syscall.Access(path, mode); err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.accessSync() failed: access %s: %s", path, err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	return 0
+}
+
+// fs.realpathSync(path) -> string
+func (engine *ESEngine) esFileRealpathSync(ctx *ESContext) int {
+	if ctx.GetTop() != 1 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.realpathSync(): expected (path)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.realpathSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.realpathSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	ctx.PushString(resolved)
+	return 1
+}
+
+// fs.readlinkSync(path) -> string
+func (engine *ESEngine) esFileReadlinkSync(ctx *ESContext) int {
+	if ctx.GetTop() != 1 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.readlinkSync(): expected (path)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	target, err := os.Readlink(path)
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.readlinkSync() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	ctx.PushString(target)
+	return 1
+}
+
+// ──────────────────────────────────────────────
+// Async functions (error-first callback pattern)
+// ──────────────────────────────────────────────
+
+// fs.readFile(path, callback) — callback(err, data)
+func (engine *ESEngine) esFileReadFile(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.readFile(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	go func() {
+		var data string
+		var readErr error
+
+		f, err := os.Open(path)
+		if err != nil {
+			readErr = err
+		} else {
+			raw, err := io.ReadAll(io.LimitReader(f, maxReadFileSize+1))
+			f.Close()
+			if err != nil {
+				readErr = err
+			} else if int64(len(raw)) > maxReadFileSize {
+				readErr = fmt.Errorf("file %s is too large (max %d bytes)", path, maxReadFileSize)
+			} else {
+				data = string(raw)
+			}
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, readErr, data)
+	}()
+
+	return 0
+}
+
+// fs.writeFile(path, data, callback) — callback(err)
+func (engine *ESEngine) esFileWriteFile(ctx *ESContext) int {
+	if ctx.GetTop() != 3 || !ctx.IsString(0) || !ctx.IsString(1) || !ctx.IsFunction(2) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.writeFile(): expected (path, data, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	data := ctx.GetString(1)
+	callbackFn := ctx.WrapCallbackArgs(2)
+
+	go func() {
+		err := atomicWriteFile(path, []byte(data), 0o644)
+
+		engine.fsAsyncCallback(ctx, callbackFn, err)
+	}()
+
+	return 0
+}
+
+// fs.appendFile(path, data, callback) — callback(err)
+func (engine *ESEngine) esFileAppendFile(ctx *ESContext) int {
+	if ctx.GetTop() != 3 || !ctx.IsString(0) || !ctx.IsString(1) || !ctx.IsFunction(2) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.appendFile(): expected (path, data, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	data := ctx.GetString(1)
+	callbackFn := ctx.WrapCallbackArgs(2)
+
+	go func() {
+		var err error
+		f, openErr := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if openErr != nil {
+			err = openErr
+		} else {
+			_, writeErr := f.WriteString(data)
+			closeErr := f.Close()
+			if writeErr != nil {
+				err = writeErr
+			} else if closeErr != nil {
+				err = closeErr
+			}
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, err)
+	}()
+
+	return 0
+}
+
+// fs.stat(path, callback) — callback(err, stats)
+func (engine *ESEngine) esFileStat(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.stat(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	go func() {
+		info, err := os.Stat(path)
+		var result map[string]any
+		if err == nil {
+			result = buildStatObj(info)
+		}
+		engine.fsAsyncCallback(ctx, callbackFn, err, result)
+	}()
+
+	return 0
+}
+
+// fs.readdir(path, callback) — callback(err, entries)
+func (engine *ESEngine) esFileReaddir(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.readdir(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	go func() {
+		entries, err := os.ReadDir(path)
+		var result []any
+		if err == nil {
+			result = make([]any, len(entries))
+			for i, entry := range entries {
+				info, infoErr := entry.Info()
+				if infoErr != nil {
+					err = infoErr
+					break
+				}
+				result[i] = buildDirEntry(entry.Name(), info)
+			}
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, err, result)
+	}()
+
+	return 0
+}
+
+// fs.exists(path, callback) — callback(exists)  (no error argument, Node.js convention).
+// Note: unlike existsSync, permission errors are silently treated as "not exists"
+// because the callback signature has no error parameter (matches Node.js behavior).
+func (engine *ESEngine) esFileExists(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.exists(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	go func() {
+		_, err := os.Stat(path)
+		exists := err == nil
+
+		engine.CallSync(func() {
+			filename, ok := engine.fsAsyncCallbackPreamble(ctx)
+			if !ok {
+				return
+			}
+			defer engine.fsAsyncCallbackPostamble(filename)
+
+			callbackFn(exists)
+		})
+	}()
+
+	return 0
+}
+
+// fs.mkdir(path, [opts,] callback) — callback(err)
+func (engine *ESEngine) esFileMkdir(ctx *ESContext) int {
+	numArgs := ctx.GetTop()
+	if numArgs < 2 || numArgs > 3 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.mkdir(): expected (path, [opts,] callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	recursive := false
+	callbackIdx := numArgs - 1
+
+	if !ctx.IsFunction(callbackIdx) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.mkdir(): last argument must be a callback function")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	if numArgs == 3 && ctx.IsObject(1) {
+		ctx.GetPropString(1, "recursive")
+		if ctx.IsBoolean(-1) {
+			recursive = ctx.GetBoolean(-1)
+		}
+		ctx.Pop()
+	}
+
+	callbackFn := ctx.WrapCallbackArgs(callbackIdx)
+
+	go func() {
+		var err error
+		if recursive {
+			err = os.MkdirAll(path, 0o755)
+		} else {
+			err = os.Mkdir(path, 0o755)
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, err)
+	}()
+
+	return 0
+}
+
+// fs.unlink(path, callback) — callback(err)
+func (engine *ESEngine) esFileUnlink(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.unlink(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	go func() {
+		var err error
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			err = statErr
+		} else if info.IsDir() {
+			err = fmt.Errorf("%s is a directory, use fs.rmdir() or remove manually", path)
+		} else {
+			err = os.Remove(path)
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, err)
+	}()
+
+	return 0
+}
+
+// fs.rename(oldPath, newPath, callback) — callback(err)
+func (engine *ESEngine) esFileRename(ctx *ESContext) int {
+	if ctx.GetTop() != 3 || !ctx.IsString(0) || !ctx.IsString(1) || !ctx.IsFunction(2) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.rename(): expected (oldPath, newPath, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	oldPath := ctx.GetString(0)
+	newPath := ctx.GetString(1)
+	callbackFn := ctx.WrapCallbackArgs(2)
+
+	go func() {
+		err := os.Rename(oldPath, newPath)
+
+		engine.fsAsyncCallback(ctx, callbackFn, err)
+	}()
+
+	return 0
+}
+
+// fs.rmdir(path, [opts,] callback) — callback(err)
+func (engine *ESEngine) esFileRmdir(ctx *ESContext) int {
+	numArgs := ctx.GetTop()
+	if numArgs < 2 || numArgs > 3 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.rmdir(): expected (path, [opts,] callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	recursive := false
+	callbackIdx := numArgs - 1
+
+	if !ctx.IsFunction(callbackIdx) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.rmdir(): last argument must be a callback function")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	if numArgs == 3 && ctx.IsObject(1) {
+		ctx.GetPropString(1, "recursive")
+		if ctx.IsBoolean(-1) {
+			recursive = ctx.GetBoolean(-1)
+		}
+		ctx.Pop()
+	}
+
+	callbackFn := ctx.WrapCallbackArgs(callbackIdx)
+
+	go func() {
+		var err error
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			err = statErr
+		} else if !info.IsDir() {
+			err = fmt.Errorf("%s is not a directory", path)
+		} else if recursive {
+			cleanPath := filepath.Clean(path)
+			if cleanPath == "/" || cleanPath == "." {
+				err = fmt.Errorf("refusing to recursively remove %q", path)
+			} else {
+				err = os.RemoveAll(path)
+			}
+		} else {
+			err = os.Remove(path)
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, err)
+	}()
+
+	return 0
+}
+
+// fs.copyFile(src, dest, callback) — callback(err)
+func (engine *ESEngine) esFileCopyFile(ctx *ESContext) int {
+	if ctx.GetTop() != 3 || !ctx.IsString(0) || !ctx.IsString(1) || !ctx.IsFunction(2) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.copyFile(): expected (src, dest, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	src := ctx.GetString(0)
+	dest := ctx.GetString(1)
+	callbackFn := ctx.WrapCallbackArgs(2)
+
+	// Guard against self-copy: use os.SameFile to handle symlinks and hard links
+	if srcInfo, statErr := os.Stat(src); statErr == nil {
+		if destInfo, statErr := os.Stat(dest); statErr == nil && os.SameFile(srcInfo, destInfo) {
+			go func() {
+				engine.fsAsyncCallback(ctx, callbackFn, nil)
+			}()
+			return 0
+		}
+	}
+
+	go func() {
+		var err error
+		srcFile, openErr := os.Open(src)
+		if openErr != nil {
+			err = openErr
+		} else {
+			var info os.FileInfo
+			info, err = srcFile.Stat()
+			if err == nil {
+				var destFile *os.File
+				destFile, err = os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+				if err == nil {
+					_, err = io.Copy(destFile, srcFile)
+					closeErr := destFile.Close()
+					if err == nil {
+						err = closeErr
+					}
+					if err != nil {
+						os.Remove(dest)
+					}
+				}
+			}
+			srcFile.Close()
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, err)
+	}()
+
+	return 0
+}
+
+// fs.access(path, [mode,] callback) — callback(err)
+func (engine *ESEngine) esFileAccess(ctx *ESContext) int {
+	numArgs := ctx.GetTop()
+	if numArgs < 2 || numArgs > 3 || !ctx.IsString(0) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.access(): expected (path, [mode,] callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	mode := uint32(syscall.F_OK)
+	callbackIdx := numArgs - 1
+
+	if !ctx.IsFunction(callbackIdx) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.access(): last argument must be a callback function")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	if numArgs == 3 && ctx.IsNumber(1) {
+		mode = uint32(ctx.GetNumber(1))
+	}
+
+	if mode > 7 {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.access() failed: invalid mode %d", mode))
+		return duktape.DUK_RET_ERROR
+	}
+
+	callbackFn := ctx.WrapCallbackArgs(callbackIdx)
+
+	go func() {
+		var accessErr error
+		if err := syscall.Access(path, mode); err != nil {
+			accessErr = fmt.Errorf("access %s: %w", path, err)
+		}
+
+		engine.fsAsyncCallback(ctx, callbackFn, accessErr)
+	}()
+
+	return 0
+}
+
+// fs.realpath(path, callback) — callback(err, resolvedPath)
+func (engine *ESEngine) esFileRealpath(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.realpath(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	go func() {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err == nil {
+			resolved, err = filepath.Abs(resolved)
+		}
+		engine.fsAsyncCallback(ctx, callbackFn, err, resolved)
+	}()
+
+	return 0
+}
+
+// fs.readlink(path, callback) — callback(err, target)
+func (engine *ESEngine) esFileReadlink(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.readlink(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	go func() {
+		target, err := os.Readlink(path)
+		engine.fsAsyncCallback(ctx, callbackFn, err, target)
+	}()
+
+	return 0
+}
+
+// fs.watch(path, callback) — returns {close: function()}
+// callback(eventType, filename) where eventType is "change" or "rename"
+func (engine *ESEngine) esFileWatch(ctx *ESContext) int {
+	if ctx.GetTop() != 2 || !ctx.IsString(0) || !ctx.IsFunction(1) {
+		engine.Log(ENGINE_LOG_ERROR, "fs.watch(): expected (path, callback)")
+		return duktape.DUK_RET_TYPE_ERROR
+	}
+
+	path := ctx.GetString(0)
+	callbackFn := ctx.WrapCallbackArgs(1)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.watch() failed: %s", err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	if err := watcher.Add(path); err != nil {
+		watcher.Close()
+		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("fs.watch() failed: %s: %s", path, err))
+		return duktape.DUK_RET_ERROR
+	}
+
+	var closeOnce sync.Once
+	closeFn := func() {
+		closeOnce.Do(func() {
+			watcher.Close()
+		})
+	}
+
+	// Register cleanup so watcher is closed on script reload
+	scriptFilename := ctx.GetCurrentFilename()
+	if scriptFilename != "" {
+		engine.cleanup.PushCleanupScope(scriptFilename)
+		engine.cleanup.AddCleanup(closeFn)
+		engine.cleanup.PopCleanupScope(scriptFilename)
+	} else {
+		wbgong.Warn.Printf("fs.watch(%s): cannot register cleanup (no script filename), watcher will leak on reload", path)
+	}
+
+	// Start goroutine to relay events
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				var eventType string
+				switch {
+				case event.Has(fsnotify.Write) || event.Has(fsnotify.Chmod):
+					eventType = "change"
+				default:
+					eventType = "rename"
+				}
+				eventFilename := filepath.Base(event.Name)
+
+				engine.CallSync(func() {
+					filename, ok := engine.fsAsyncCallbackPreamble(ctx)
+					if !ok {
+						closeFn()
+						return
+					}
+					defer engine.fsAsyncCallbackPostamble(filename)
+
+					callbackFn(eventType, eventFilename)
+				})
+			case watchErr, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				wbgong.Error.Printf("fs.watch() error on %s: %s", path, watchErr)
+			}
+		}
+	}()
+
+	// Return watcher object with close() method
+	ctx.PushObject()
+	ctx.DefineFunctions(map[string]func(*ESContext) int{
+		"close": func(_ *ESContext) int {
+			closeFn()
+			return 0
+		},
+	})
+
+	return 1
+}

--- a/wbrules/rule_fileio_test.go
+++ b/wbrules/rule_fileio_test.go
@@ -1,0 +1,1193 @@
+package wbrules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wirenboard/wbgong/testutils"
+)
+
+type RuleFileIOSuite struct {
+	RuleSuiteBase
+	tmpDir  string
+	cleanup func()
+}
+
+func (s *RuleFileIOSuite) SetupTest() {
+	s.SetupSkippingDefs("testrules_fileio.js")
+	s.tmpDir, s.cleanup = testutils.SetupTempDir(s.T())
+}
+
+func (s *RuleFileIOSuite) TearDownTest() {
+	if s.cleanup != nil {
+		s.cleanup()
+	}
+	s.RuleSuiteBase.TearDownTest()
+}
+
+func (s *RuleFileIOSuite) sendCmd(cmd string) {
+	s.publish("/devices/somedev/controls/fileCmd", cmd, "somedev/fileCmd")
+}
+
+// callCmd publishes meta/type, initial value, and actual command, then verifies all messages + expected log output.
+// This follows the pattern from rule_shell_command_test.go to handle "do not trigger whenChanged on first published value".
+func (s *RuleFileIOSuite) callCmd(cmd string, expectedMsgs ...interface{}) {
+	s.publish("/devices/somedev/controls/fileCmd/meta/type", "text", "somedev/fileCmd")
+	s.publish("/devices/somedev/controls/fileCmd", "initial_text", "somedev/fileCmd")
+	s.sendCmd(cmd)
+
+	msgs := []interface{}{
+		"tst -> /devices/somedev/controls/fileCmd/meta/type: [text] (QoS 1, retained)",
+		"tst -> /devices/somedev/controls/fileCmd: [initial_text] (QoS 1, retained)",
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [%s] (QoS 1, retained)", cmd),
+	}
+	msgs = append(msgs, expectedMsgs...)
+	s.Verify(msgs...)
+}
+
+// ──────────────────────────────────────────────
+// Sync tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestWriteAndReadFile() {
+	p := filepath.Join(s.tmpDir, "test.txt")
+
+	s.callCmd(
+		fmt.Sprintf("writeFile|%s|hello world", p),
+		"[info] writeFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("readFile|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [readFile|%s] (QoS 1, retained)", p),
+		"[info] readFile: [hello world]",
+	)
+}
+
+func (s *RuleFileIOSuite) TestReadFileNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("readFile|%s", p),
+		fmt.Sprintf("[error] fs.readFileSync() failed: open %s: no such file or directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestReadFileEmptyString() {
+	p := filepath.Join(s.tmpDir, "empty.txt")
+	os.WriteFile(p, []byte(""), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("readFile|%s", p),
+		"[info] readFile: []",
+	)
+}
+
+func (s *RuleFileIOSuite) TestWriteFileEmptyString() {
+	p := filepath.Join(s.tmpDir, "empty_write.txt")
+	s.callCmd(
+		fmt.Sprintf("writeFile|%s|", p),
+		"[info] writeFile: ok",
+	)
+
+	data, err := os.ReadFile(p)
+	s.Require().NoError(err)
+	s.Empty(string(data))
+}
+
+func (s *RuleFileIOSuite) TestAppendFile() {
+	p := filepath.Join(s.tmpDir, "append.txt")
+
+	s.callCmd(
+		fmt.Sprintf("writeFile|%s|first", p),
+		"[info] writeFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("appendFile|%s| second", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [appendFile|%s| second] (QoS 1, retained)", p),
+		"[info] appendFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("readFile|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [readFile|%s] (QoS 1, retained)", p),
+		"[info] readFile: [first second]",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAppendFileNonExistent() {
+	p := filepath.Join(s.tmpDir, "append_new.txt")
+	s.callCmd(
+		fmt.Sprintf("appendFile|%s|created by append", p),
+		"[info] appendFile: ok",
+	)
+
+	data, err := os.ReadFile(p)
+	s.Require().NoError(err)
+	s.Equal("created by append", string(data))
+}
+
+func (s *RuleFileIOSuite) TestStat() {
+	p := filepath.Join(s.tmpDir, "statfile.txt")
+	os.WriteFile(p, []byte("12345"), 0o644)
+
+	info, err := os.Stat(p)
+	s.Require().NoError(err)
+
+	s.callCmd(
+		fmt.Sprintf("stat|%s", p),
+		fmt.Sprintf("[info] stat: size=5 isFile=true isDirectory=false mode=644 mtime=%d", info.ModTime().Unix()),
+	)
+}
+
+func (s *RuleFileIOSuite) TestStatDirectory() {
+	d := filepath.Join(s.tmpDir, "subdir")
+	os.Mkdir(d, 0o755)
+
+	info, err := os.Stat(d)
+	s.Require().NoError(err)
+
+	s.callCmd(
+		fmt.Sprintf("stat|%s", d),
+		fmt.Sprintf("[info] stat: size=%d isFile=false isDirectory=true mode=755 mtime=%d", info.Size(), info.ModTime().Unix()),
+	)
+}
+
+func (s *RuleFileIOSuite) TestStatNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent")
+	s.callCmd(
+		fmt.Sprintf("stat|%s", p),
+		fmt.Sprintf("[error] fs.statSync() failed: stat %s: no such file or directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestReadDir() {
+	os.WriteFile(filepath.Join(s.tmpDir, "aaa.txt"), []byte("a"), 0o644)
+	os.WriteFile(filepath.Join(s.tmpDir, "bbb.txt"), []byte("b"), 0o644)
+	os.Mkdir(filepath.Join(s.tmpDir, "ccc"), 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("readDir|%s", s.tmpDir),
+		"[info] readDir: aaa.txt(file=true,dir=false),bbb.txt(file=true,dir=false),ccc(file=false,dir=true)",
+	)
+}
+
+func (s *RuleFileIOSuite) TestReadDirNonExistent() {
+	p := filepath.Join(s.tmpDir, "no_such_dir")
+	s.callCmd(
+		fmt.Sprintf("readDir|%s", p),
+		fmt.Sprintf("[error] fs.readdirSync() failed: open %s: no such file or directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestReadDirEmpty() {
+	d := filepath.Join(s.tmpDir, "emptydir")
+	os.Mkdir(d, 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("readDir|%s", d),
+		"[info] readDir: ",
+	)
+}
+
+func (s *RuleFileIOSuite) TestExists() {
+	p := filepath.Join(s.tmpDir, "existing.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("exists|%s", p),
+		"[info] exists: true",
+	)
+}
+
+func (s *RuleFileIOSuite) TestExistsNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("exists|%s", p),
+		"[info] exists: false",
+	)
+}
+
+func (s *RuleFileIOSuite) TestMkdir() {
+	d := filepath.Join(s.tmpDir, "newdir")
+	s.callCmd(
+		fmt.Sprintf("mkdir|%s", d),
+		"[info] mkdir: ok",
+	)
+
+	info, err := os.Stat(d)
+	s.Require().NoError(err)
+	s.True(info.IsDir())
+}
+
+func (s *RuleFileIOSuite) TestMkdirRecursive() {
+	d := filepath.Join(s.tmpDir, "a", "b", "c")
+	s.callCmd(
+		fmt.Sprintf("mkdir|%s|recursive", d),
+		"[info] mkdir: ok",
+	)
+
+	info, err := os.Stat(d)
+	s.Require().NoError(err)
+	s.True(info.IsDir())
+}
+
+func (s *RuleFileIOSuite) TestMkdirAlreadyExists() {
+	d := filepath.Join(s.tmpDir, "existingdir")
+	os.Mkdir(d, 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("mkdir|%s", d),
+		fmt.Sprintf("[error] fs.mkdirSync() failed: mkdir %s: file exists", d),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestUnlink() {
+	p := filepath.Join(s.tmpDir, "todelete.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("unlink|%s", p),
+		"[info] unlink: ok",
+	)
+
+	_, err := os.Stat(p)
+	s.True(os.IsNotExist(err))
+}
+
+func (s *RuleFileIOSuite) TestUnlinkNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("unlink|%s", p),
+		fmt.Sprintf("[error] fs.unlinkSync() failed: lstat %s: no such file or directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestUnlinkDirectory() {
+	d := filepath.Join(s.tmpDir, "cantdelete")
+	os.Mkdir(d, 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("unlinkDir|%s", d),
+		fmt.Sprintf("[error] fs.unlinkSync() failed: %s is a directory, use fs.rmdirSync() or remove manually", d),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestRename() {
+	oldPath := filepath.Join(s.tmpDir, "old.txt")
+	newPath := filepath.Join(s.tmpDir, "new.txt")
+	os.WriteFile(oldPath, []byte("content"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("rename|%s|%s", oldPath, newPath),
+		"[info] rename: ok",
+	)
+
+	_, err := os.Stat(oldPath)
+	s.True(os.IsNotExist(err))
+
+	data, err := os.ReadFile(newPath)
+	s.Require().NoError(err)
+	s.Equal("content", string(data))
+}
+
+func (s *RuleFileIOSuite) TestRenameNonExistent() {
+	oldPath := filepath.Join(s.tmpDir, "no_such_file.txt")
+	newPath := filepath.Join(s.tmpDir, "new.txt")
+	s.callCmd(
+		fmt.Sprintf("rename|%s|%s", oldPath, newPath),
+		fmt.Sprintf("[error] fs.renameSync() failed: rename %s %s: no such file or directory", oldPath, newPath),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+// ──────────────────────────────────────────────
+// rmdir tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestRmdir() {
+	d := filepath.Join(s.tmpDir, "rmdir_me")
+	os.Mkdir(d, 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("rmdir|%s", d),
+		"[info] rmdir: ok",
+	)
+
+	_, err := os.Stat(d)
+	s.True(os.IsNotExist(err))
+}
+
+func (s *RuleFileIOSuite) TestRmdirRecursive() {
+	d := filepath.Join(s.tmpDir, "rmdir_recursive")
+	os.MkdirAll(filepath.Join(d, "sub", "deep"), 0o755)
+	os.WriteFile(filepath.Join(d, "sub", "file.txt"), []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("rmdir|%s|recursive", d),
+		"[info] rmdir: ok",
+	)
+
+	_, err := os.Stat(d)
+	s.True(os.IsNotExist(err))
+}
+
+func (s *RuleFileIOSuite) TestRmdirNonEmpty() {
+	d := filepath.Join(s.tmpDir, "notempty")
+	os.Mkdir(d, 0o755)
+	os.WriteFile(filepath.Join(d, "file.txt"), []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("rmdir|%s", d),
+		fmt.Sprintf("[error] fs.rmdirSync() failed: remove %s: directory not empty", d),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestRmdirFile() {
+	p := filepath.Join(s.tmpDir, "notadir.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("rmdir|%s", p),
+		fmt.Sprintf("[error] fs.rmdirSync() failed: %s is not a directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestRmdirNonExistent() {
+	d := filepath.Join(s.tmpDir, "no_such_dir")
+	s.callCmd(
+		fmt.Sprintf("rmdir|%s", d),
+		fmt.Sprintf("[error] fs.rmdirSync() failed: lstat %s: no such file or directory", d),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+// ──────────────────────────────────────────────
+// copyFile tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestCopyFile() {
+	src := filepath.Join(s.tmpDir, "source.txt")
+	dest := filepath.Join(s.tmpDir, "dest.txt")
+	os.WriteFile(src, []byte("copy me"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("copyFile|%s|%s", src, dest),
+		"[info] copyFile: ok",
+	)
+
+	data, err := os.ReadFile(dest)
+	s.Require().NoError(err)
+	s.Equal("copy me", string(data))
+
+	// source should still exist
+	_, err = os.Stat(src)
+	s.Require().NoError(err)
+}
+
+func (s *RuleFileIOSuite) TestCopyFilePreservesPermissions() {
+	src := filepath.Join(s.tmpDir, "exec_source.sh")
+	dest := filepath.Join(s.tmpDir, "exec_dest.sh")
+	os.WriteFile(src, []byte("#!/bin/sh"), 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("copyFile|%s|%s", src, dest),
+		"[info] copyFile: ok",
+	)
+
+	info, err := os.Stat(dest)
+	s.Require().NoError(err)
+	s.Equal(os.FileMode(0o755), info.Mode().Perm())
+}
+
+func (s *RuleFileIOSuite) TestCopyFileNonExistent() {
+	src := filepath.Join(s.tmpDir, "nonexistent.txt")
+	dest := filepath.Join(s.tmpDir, "dest.txt")
+	s.callCmd(
+		fmt.Sprintf("copyFile|%s|%s", src, dest),
+		fmt.Sprintf("[error] fs.copyFileSync() failed: open %s: no such file or directory", src),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+// ──────────────────────────────────────────────
+// access tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAccess() {
+	p := filepath.Join(s.tmpDir, "accessible.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("access|%s", p),
+		"[info] access: ok",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAccessReadable() {
+	p := filepath.Join(s.tmpDir, "readable.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	// R_OK = 4
+	s.callCmd(
+		fmt.Sprintf("access|%s|4", p),
+		"[info] access: ok",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAccessNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("access|%s", p),
+		fmt.Sprintf("[error] fs.accessSync() failed: access %s: no such file or directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestAccessConstants() {
+	s.callCmd(
+		"accessConstants",
+		"[info] F_OK=0 R_OK=4 W_OK=2 X_OK=1",
+	)
+}
+
+// ──────────────────────────────────────────────
+// realpath tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestRealpath() {
+	p := filepath.Join(s.tmpDir, "realfile.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	link := filepath.Join(s.tmpDir, "link_to_file")
+	os.Symlink(p, link)
+
+	s.callCmd(
+		fmt.Sprintf("realpath|%s", link),
+		fmt.Sprintf("[info] realpath: %s", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestRealpathNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent")
+	s.callCmd(
+		fmt.Sprintf("realpath|%s", p),
+		fmt.Sprintf("[error] fs.realpathSync() failed: lstat %s: no such file or directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+// ──────────────────────────────────────────────
+// readlink tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestReadlink() {
+	target := filepath.Join(s.tmpDir, "target.txt")
+	os.WriteFile(target, []byte("x"), 0o644)
+
+	link := filepath.Join(s.tmpDir, "symlink")
+	os.Symlink(target, link)
+
+	s.callCmd(
+		fmt.Sprintf("readlink|%s", link),
+		fmt.Sprintf("[info] readlink: %s", target),
+	)
+}
+
+func (s *RuleFileIOSuite) TestReadlinkNotSymlink() {
+	p := filepath.Join(s.tmpDir, "regular.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("readlink|%s", p),
+		fmt.Sprintf("[error] fs.readlinkSync() failed: readlink %s: invalid argument", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestWriteFileOverwrite() {
+	p := filepath.Join(s.tmpDir, "overwrite.txt")
+
+	s.callCmd(
+		fmt.Sprintf("writeFile|%s|original", p),
+		"[info] writeFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("writeFile|%s|updated", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [writeFile|%s|updated] (QoS 1, retained)", p),
+		"[info] writeFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("readFile|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [readFile|%s] (QoS 1, retained)", p),
+		"[info] readFile: [updated]",
+	)
+}
+
+func (s *RuleFileIOSuite) TestWrongArgTypes() {
+	// readFileSync with no args
+	s.callCmd(
+		"readFileNoArgs",
+		"[error] fs.readFileSync(): expected (path)",
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+
+	// writeFileSync with one arg
+	p := filepath.Join(s.tmpDir, "test.txt")
+	s.sendCmd(fmt.Sprintf("writeFileOneArg|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [writeFileOneArg|%s] (QoS 1, retained)", p),
+		"[error] fs.writeFileSync(): expected (path, data)",
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+
+	// statSync with no args
+	s.sendCmd("statNoArgs")
+	s.Verify(
+		"tst -> /devices/somedev/controls/fileCmd: [statNoArgs] (QoS 1, retained)",
+		"[error] fs.statSync(): expected (path)",
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+// ──────────────────────────────────────────────
+// Async tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAsyncWriteAndReadFile() {
+	p := filepath.Join(s.tmpDir, "async_test.txt")
+
+	s.callCmd(
+		fmt.Sprintf("asyncWriteFile|%s|async hello", p),
+		"[info] asyncWriteFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("asyncReadFile|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [asyncReadFile|%s] (QoS 1, retained)", p),
+		"[info] asyncReadFile: [async hello]",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncReadFileNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncReadFile|%s", p),
+		fmt.Sprintf("[info] asyncReadFile error: open %s: no such file or directory", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncWriteFileError() {
+	// Writing to a non-existent directory should produce an error
+	p := filepath.Join(s.tmpDir, "no_such_dir", "file.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncWriteFile|%s|data", p),
+		fmt.Sprintf("[info] asyncWriteFile error: open %s: no such file or directory", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncAppendFileError() {
+	// Appending to a file in a non-existent directory should produce an error
+	p := filepath.Join(s.tmpDir, "no_such_dir", "file.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncAppendFile|%s|data", p),
+		fmt.Sprintf("[info] asyncAppendFile error: open %s: no such file or directory", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncAppendFile() {
+	p := filepath.Join(s.tmpDir, "async_append.txt")
+
+	s.callCmd(
+		fmt.Sprintf("asyncWriteFile|%s|first", p),
+		"[info] asyncWriteFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("asyncAppendFile|%s| second", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [asyncAppendFile|%s| second] (QoS 1, retained)", p),
+		"[info] asyncAppendFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("asyncReadFile|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [asyncReadFile|%s] (QoS 1, retained)", p),
+		"[info] asyncReadFile: [first second]",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncStat() {
+	p := filepath.Join(s.tmpDir, "async_stat.txt")
+	os.WriteFile(p, []byte("12345"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncStat|%s", p),
+		"[info] asyncStat: size=5 isFile=true isDirectory=false",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncStatNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent")
+	s.callCmd(
+		fmt.Sprintf("asyncStat|%s", p),
+		fmt.Sprintf("[info] asyncStat error: stat %s: no such file or directory", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncReaddir() {
+	os.WriteFile(filepath.Join(s.tmpDir, "aaa.txt"), []byte("a"), 0o644)
+	os.WriteFile(filepath.Join(s.tmpDir, "bbb.txt"), []byte("b"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncReaddir|%s", s.tmpDir),
+		"[info] asyncReaddir: aaa.txt,bbb.txt",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncReaddirNonExistent() {
+	p := filepath.Join(s.tmpDir, "no_such_dir")
+	s.callCmd(
+		fmt.Sprintf("asyncReaddir|%s", p),
+		fmt.Sprintf("[info] asyncReaddir error: open %s: no such file or directory", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncExists() {
+	p := filepath.Join(s.tmpDir, "async_exists.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncExists|%s", p),
+		"[info] asyncExists: true",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncExistsNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncExists|%s", p),
+		"[info] asyncExists: false",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncMkdir() {
+	d := filepath.Join(s.tmpDir, "async_newdir")
+	s.callCmd(
+		fmt.Sprintf("asyncMkdir|%s", d),
+		"[info] asyncMkdir: ok",
+	)
+
+	info, err := os.Stat(d)
+	s.Require().NoError(err)
+	s.True(info.IsDir())
+}
+
+func (s *RuleFileIOSuite) TestAsyncMkdirRecursive() {
+	d := filepath.Join(s.tmpDir, "a", "b", "c")
+	s.callCmd(
+		fmt.Sprintf("asyncMkdir|%s|recursive", d),
+		"[info] asyncMkdir: ok",
+	)
+
+	info, err := os.Stat(d)
+	s.Require().NoError(err)
+	s.True(info.IsDir())
+}
+
+func (s *RuleFileIOSuite) TestAsyncMkdirAlreadyExists() {
+	d := filepath.Join(s.tmpDir, "existingdir")
+	os.Mkdir(d, 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("asyncMkdir|%s", d),
+		fmt.Sprintf("[info] asyncMkdir error: mkdir %s: file exists", d),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncUnlink() {
+	p := filepath.Join(s.tmpDir, "async_todelete.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncUnlink|%s", p),
+		"[info] asyncUnlink: ok",
+	)
+
+	_, err := os.Stat(p)
+	s.True(os.IsNotExist(err))
+}
+
+func (s *RuleFileIOSuite) TestAsyncUnlinkNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncUnlink|%s", p),
+		fmt.Sprintf("[info] asyncUnlink error: lstat %s: no such file or directory", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncRename() {
+	oldPath := filepath.Join(s.tmpDir, "async_old.txt")
+	newPath := filepath.Join(s.tmpDir, "async_new.txt")
+	os.WriteFile(oldPath, []byte("content"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncRename|%s|%s", oldPath, newPath),
+		"[info] asyncRename: ok",
+	)
+
+	_, err := os.Stat(oldPath)
+	s.True(os.IsNotExist(err))
+
+	data, err := os.ReadFile(newPath)
+	s.Require().NoError(err)
+	s.Equal("content", string(data))
+}
+
+func (s *RuleFileIOSuite) TestAsyncRenameNonExistent() {
+	oldPath := filepath.Join(s.tmpDir, "no_such_file.txt")
+	newPath := filepath.Join(s.tmpDir, "new.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncRename|%s|%s", oldPath, newPath),
+		fmt.Sprintf("[info] asyncRename error: rename %s %s: no such file or directory", oldPath, newPath),
+	)
+}
+
+// ──────────────────────────────────────────────
+// Async rmdir tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAsyncRmdir() {
+	d := filepath.Join(s.tmpDir, "async_rmdir")
+	os.Mkdir(d, 0o755)
+
+	s.callCmd(
+		fmt.Sprintf("asyncRmdir|%s", d),
+		"[info] asyncRmdir: ok",
+	)
+
+	_, err := os.Stat(d)
+	s.True(os.IsNotExist(err))
+}
+
+func (s *RuleFileIOSuite) TestAsyncRmdirRecursive() {
+	d := filepath.Join(s.tmpDir, "async_rmdir_rec")
+	os.MkdirAll(filepath.Join(d, "sub"), 0o755)
+	os.WriteFile(filepath.Join(d, "sub", "file.txt"), []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncRmdir|%s|recursive", d),
+		"[info] asyncRmdir: ok",
+	)
+
+	_, err := os.Stat(d)
+	s.True(os.IsNotExist(err))
+}
+
+func (s *RuleFileIOSuite) TestAsyncRmdirFile() {
+	p := filepath.Join(s.tmpDir, "async_notadir.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncRmdir|%s", p),
+		fmt.Sprintf("[info] asyncRmdir error: %s is not a directory", p),
+	)
+}
+
+// ──────────────────────────────────────────────
+// Async copyFile tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAsyncCopyFile() {
+	src := filepath.Join(s.tmpDir, "async_src.txt")
+	dest := filepath.Join(s.tmpDir, "async_dest.txt")
+	os.WriteFile(src, []byte("async copy"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncCopyFile|%s|%s", src, dest),
+		"[info] asyncCopyFile: ok",
+	)
+
+	data, err := os.ReadFile(dest)
+	s.Require().NoError(err)
+	s.Equal("async copy", string(data))
+}
+
+func (s *RuleFileIOSuite) TestAsyncCopyFileNonExistent() {
+	src := filepath.Join(s.tmpDir, "nonexistent.txt")
+	dest := filepath.Join(s.tmpDir, "dest.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncCopyFile|%s|%s", src, dest),
+		fmt.Sprintf("[info] asyncCopyFile error: open %s: no such file or directory", src),
+	)
+}
+
+// ──────────────────────────────────────────────
+// Async access tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAsyncAccess() {
+	p := filepath.Join(s.tmpDir, "async_access.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncAccess|%s", p),
+		"[info] asyncAccess: ok",
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncAccessNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncAccess|%s", p),
+		fmt.Sprintf("[info] asyncAccess error: access %s: no such file or directory", p),
+	)
+}
+
+// ──────────────────────────────────────────────
+// Async realpath tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAsyncRealpath() {
+	p := filepath.Join(s.tmpDir, "async_real.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	link := filepath.Join(s.tmpDir, "async_link")
+	os.Symlink(p, link)
+
+	s.callCmd(
+		fmt.Sprintf("asyncRealpath|%s", link),
+		fmt.Sprintf("[info] asyncRealpath: %s", p),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncRealpathNonExistent() {
+	p := filepath.Join(s.tmpDir, "nonexistent")
+	s.callCmd(
+		fmt.Sprintf("asyncRealpath|%s", p),
+		fmt.Sprintf("[info] asyncRealpath error: lstat %s: no such file or directory", p),
+	)
+}
+
+// ──────────────────────────────────────────────
+// Async readlink tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAsyncReadlink() {
+	target := filepath.Join(s.tmpDir, "async_target.txt")
+	os.WriteFile(target, []byte("x"), 0o644)
+
+	link := filepath.Join(s.tmpDir, "async_symlink")
+	os.Symlink(target, link)
+
+	s.callCmd(
+		fmt.Sprintf("asyncReadlink|%s", link),
+		fmt.Sprintf("[info] asyncReadlink: %s", target),
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncReadlinkNotSymlink() {
+	p := filepath.Join(s.tmpDir, "async_regular.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncReadlink|%s", p),
+		fmt.Sprintf("[info] asyncReadlink error: readlink %s: invalid argument", p),
+	)
+}
+
+// ──────────────────────────────────────────────
+// Async access with specific mode test
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestAsyncAccessReadable() {
+	p := filepath.Join(s.tmpDir, "async_readable.txt")
+	os.WriteFile(p, []byte("x"), 0o644)
+
+	// R_OK = 4
+	s.callCmd(
+		fmt.Sprintf("asyncAccess|%s|4", p),
+		"[info] asyncAccess: ok",
+	)
+}
+
+// ──────────────────────────────────────────────
+// rmdir recursive safety tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestRmdirRecursiveRootRefused() {
+	s.callCmd(
+		"rmdir|/|recursive",
+		`[error] fs.rmdirSync() failed: refusing to recursively remove "/"`,
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestRmdirRecursiveDotRefused() {
+	s.callCmd(
+		"rmdir|.|recursive",
+		`[error] fs.rmdirSync() failed: refusing to recursively remove "."`,
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestAsyncRmdirRecursiveRootRefused() {
+	s.callCmd(
+		"asyncRmdir|/|recursive",
+		`[info] asyncRmdir error: refusing to recursively remove "/"`,
+	)
+}
+
+func (s *RuleFileIOSuite) TestAsyncRmdirRecursiveDotRefused() {
+	s.callCmd(
+		"asyncRmdir|.|recursive",
+		`[info] asyncRmdir error: refusing to recursively remove "."`,
+	)
+}
+
+// ──────────────────────────────────────────────
+// Watch tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestWatchNonExistent() {
+	p := filepath.Join(s.tmpDir, "no_such_file_for_watch")
+	s.callCmd(
+		fmt.Sprintf("watchNonExistent|%s", p),
+		fmt.Sprintf("[error] fs.watch() failed: %s: no such file or directory", p),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestWatch() {
+	p := filepath.Join(s.tmpDir, "watched.txt")
+	os.WriteFile(p, []byte("initial"), 0o644)
+
+	// Start watching the file
+	s.callCmd(
+		fmt.Sprintf("watch|%s", p),
+		"[info] watch: started",
+	)
+
+	// Modify the file to trigger an event
+	os.WriteFile(p, []byte("modified"), 0o644)
+
+	// Wait for the watch event
+	s.SkipTill("[info] watch: change watched.txt")
+
+	// Close the watcher
+	s.sendCmd("watchClose")
+	s.SkipTill("[info] watch: closed")
+}
+
+func (s *RuleFileIOSuite) TestWatchDirectory() {
+	d := filepath.Join(s.tmpDir, "watchdir")
+	os.MkdirAll(d, 0o755)
+
+	// Start watching the directory
+	s.callCmd(
+		fmt.Sprintf("watchDir|%s", d),
+		"[info] watchDir: started",
+	)
+
+	// Create a new file inside the directory — should trigger a "rename" event
+	newFile := filepath.Join(d, "newfile.txt")
+	os.WriteFile(newFile, []byte("hello"), 0o644)
+
+	s.SkipTill("[info] watchDir: rename newfile.txt")
+
+	// Close the watcher
+	s.sendCmd("watchDirClose")
+	s.SkipTill("[info] watchDir: closed")
+}
+
+func (s *RuleFileIOSuite) TestAsyncWrongArgTypes() {
+	// readFile without callback
+	p := filepath.Join(s.tmpDir, "test.txt")
+	s.callCmd(
+		fmt.Sprintf("asyncReadFileNoCallback|%s", p),
+		"[error] fs.readFile(): expected (path, callback)",
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+
+	// writeFile without callback
+	s.sendCmd(fmt.Sprintf("asyncWriteFileNoCallback|%s|data", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [asyncWriteFileNoCallback|%s|data] (QoS 1, retained)", p),
+		"[error] fs.writeFile(): expected (path, data, callback)",
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+
+	// stat without callback
+	s.sendCmd(fmt.Sprintf("asyncStatNoCallback|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [asyncStatNoCallback|%s] (QoS 1, retained)", p),
+		"[error] fs.stat(): expected (path, callback)",
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+// ──────────────────────────────────────────────
+// readFile size limit test
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestReadFileTooLarge() {
+	p := filepath.Join(s.tmpDir, "large.txt")
+	// Create a file just over 10 MB
+	f, err := os.Create(p)
+	s.Require().NoError(err)
+	buf := make([]byte, 10*1024*1024+1)
+	for i := range buf {
+		buf[i] = 'A'
+	}
+	_, err = f.Write(buf)
+	s.Require().NoError(err)
+	f.Close()
+
+	s.callCmd(
+		fmt.Sprintf("readFile|%s", p),
+		fmt.Sprintf("[error] fs.readFileSync() failed: file %s is too large (max %d bytes)", p, 10*1024*1024),
+		"[error] caught error",
+	)
+	s.EnsureGotErrors()
+}
+
+func (s *RuleFileIOSuite) TestAsyncReadFileTooLarge() {
+	p := filepath.Join(s.tmpDir, "large_async.txt")
+	f, err := os.Create(p)
+	s.Require().NoError(err)
+	buf := make([]byte, 10*1024*1024+1)
+	for i := range buf {
+		buf[i] = 'A'
+	}
+	_, err = f.Write(buf)
+	s.Require().NoError(err)
+	f.Close()
+
+	s.callCmd(
+		fmt.Sprintf("asyncReadFile|%s", p),
+		fmt.Sprintf("[info] asyncReadFile error: file %s is too large (max %d bytes)", p, 10*1024*1024),
+	)
+}
+
+// ──────────────────────────────────────────────
+// Self-copy guard tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestCopyFileSelfCopy() {
+	p := filepath.Join(s.tmpDir, "selfcopy.txt")
+	os.WriteFile(p, []byte("precious data"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("copyFile|%s|%s", p, p),
+		"[info] copyFile: ok",
+	)
+
+	data, err := os.ReadFile(p)
+	s.Require().NoError(err)
+	s.Equal("precious data", string(data))
+}
+
+func (s *RuleFileIOSuite) TestAsyncCopyFileSelfCopy() {
+	p := filepath.Join(s.tmpDir, "async_selfcopy.txt")
+	os.WriteFile(p, []byte("precious data"), 0o644)
+
+	s.callCmd(
+		fmt.Sprintf("asyncCopyFile|%s|%s", p, p),
+		"[info] asyncCopyFile: ok",
+	)
+
+	data, err := os.ReadFile(p)
+	s.Require().NoError(err)
+	s.Equal("precious data", string(data))
+}
+
+func (s *RuleFileIOSuite) TestCopyFileSelfCopyViaSymlink() {
+	p := filepath.Join(s.tmpDir, "original.txt")
+	link := filepath.Join(s.tmpDir, "link_to_original")
+	os.WriteFile(p, []byte("precious data"), 0o644)
+	os.Symlink(p, link)
+
+	s.callCmd(
+		fmt.Sprintf("copyFile|%s|%s", link, p),
+		"[info] copyFile: ok",
+	)
+
+	data, err := os.ReadFile(p)
+	s.Require().NoError(err)
+	s.Equal("precious data", string(data))
+}
+
+func (s *RuleFileIOSuite) TestAsyncCopyFileSelfCopyViaSymlink() {
+	p := filepath.Join(s.tmpDir, "async_original.txt")
+	link := filepath.Join(s.tmpDir, "async_link_to_original")
+	os.WriteFile(p, []byte("precious data"), 0o644)
+	os.Symlink(p, link)
+
+	s.callCmd(
+		fmt.Sprintf("asyncCopyFile|%s|%s", link, p),
+		"[info] asyncCopyFile: ok",
+	)
+
+	data, err := os.ReadFile(p)
+	s.Require().NoError(err)
+	s.Equal("precious data", string(data))
+}
+
+// ──────────────────────────────────────────────
+// UTF-8 / multi-byte string tests
+// ──────────────────────────────────────────────
+
+func (s *RuleFileIOSuite) TestWriteReadUTF8() {
+	p := filepath.Join(s.tmpDir, "utf8.txt")
+	// Multi-byte: Cyrillic, emoji, CJK
+	s.callCmd(
+		fmt.Sprintf("writeFile|%s|Привет мир 🌍 你好", p),
+		"[info] writeFile: ok",
+	)
+
+	s.sendCmd(fmt.Sprintf("readFile|%s", p))
+	s.Verify(
+		fmt.Sprintf("tst -> /devices/somedev/controls/fileCmd: [readFile|%s] (QoS 1, retained)", p),
+		"[info] readFile: [Привет мир 🌍 你好]",
+	)
+}
+
+func TestRuleFileIOSuite(t *testing.T) {
+	testutils.RunSuites(t,
+		new(RuleFileIOSuite),
+	)
+}

--- a/wbrules/testrules_fileio.js
+++ b/wbrules/testrules_fileio.js
@@ -1,0 +1,236 @@
+/* global defineRule, fs, log */
+/* eslint-disable no-restricted-syntax, no-unused-vars, security/detect-object-injection */
+
+// Helper: standard async callback that logs "opName: ok" or "opName error: ..."
+function asyncCallback(opName, formatResult) {
+  return function (err, result) {
+    if (err) {
+      log(opName + ' error: {}', err.message);
+    } else if (formatResult) {
+      formatResult(result);
+    } else {
+      log(opName + ': ok');
+    }
+  };
+}
+
+// Sync operation handlers: each receives parts[] from the command string
+var syncOps = {
+  readFile: function (parts) {
+    log('readFile: [{}]', fs.readFileSync(parts[1]));
+  },
+  writeFile: function (parts) {
+    fs.writeFileSync(parts[1], parts.slice(2).join('|'));
+    log('writeFile: ok');
+  },
+  appendFile: function (parts) {
+    fs.appendFileSync(parts[1], parts.slice(2).join('|'));
+    log('appendFile: ok');
+  },
+  stat: function (parts) {
+    var st = fs.statSync(parts[1]);
+    log('stat: size={} isFile={} isDirectory={} mode={} mtime={}',
+      st.size, st.isFile, st.isDirectory, st.mode, st.mtime);
+  },
+  readDir: function (parts) {
+    var entries = fs.readdirSync(parts[1]);
+    var names = [];
+    for (var i = 0; i < entries.length; i++) {
+      names.push(entries[i].name + '(file=' + entries[i].isFile + ',dir=' + entries[i].isDirectory + ')');
+    }
+    names.sort();
+    log('readDir: {}', names.join(','));
+  },
+  exists: function (parts) {
+    log('exists: {}', fs.existsSync(parts[1]));
+  },
+  mkdir: function (parts) {
+    var opts = parts[2] === 'recursive' ? {recursive: true} : undefined;
+    opts ? fs.mkdirSync(parts[1], opts) : fs.mkdirSync(parts[1]);
+    log('mkdir: ok');
+  },
+  unlink: function (parts) {
+    fs.unlinkSync(parts[1]);
+    log('unlink: ok');
+  },
+  rename: function (parts) {
+    fs.renameSync(parts[1], parts[2]);
+    log('rename: ok');
+  },
+  rmdir: function (parts) {
+    var opts = parts[2] === 'recursive' ? {recursive: true} : undefined;
+    opts ? fs.rmdirSync(parts[1], opts) : fs.rmdirSync(parts[1]);
+    log('rmdir: ok');
+  },
+  copyFile: function (parts) {
+    fs.copyFileSync(parts[1], parts[2]);
+    log('copyFile: ok');
+  },
+  access: function (parts) {
+    parts[2] ? fs.accessSync(parts[1], parseInt(parts[2])) : fs.accessSync(parts[1]);
+    log('access: ok');
+  },
+  realpath: function (parts) {
+    log('realpath: {}', fs.realpathSync(parts[1]));
+  },
+  readlink: function (parts) {
+    log('readlink: {}', fs.readlinkSync(parts[1]));
+  },
+  accessConstants: function () {
+    log('F_OK={} R_OK={} W_OK={} X_OK={}',
+      fs.constants.F_OK, fs.constants.R_OK, fs.constants.W_OK, fs.constants.X_OK);
+  },
+
+  // Error cases: wrong args
+  readFileNoArgs: function () {
+    fs.readFileSync();
+    log('readFile: should not reach');
+  },
+  writeFileOneArg: function (parts) {
+    fs.writeFileSync(parts[1]);
+    log('writeFile: should not reach');
+  },
+  statNoArgs: function () {
+    fs.statSync();
+    log('stat: should not reach');
+  },
+  readFileInt: function () {
+    fs.readFileSync(123);
+    log('readFile: should not reach');
+  },
+  unlinkDir: function (parts) {
+    fs.unlinkSync(parts[1]);
+    log('unlink: should not reach');
+  },
+};
+
+// Async operation handlers
+var asyncOps = {
+  asyncReadFile: function (parts) {
+    fs.readFile(parts[1], asyncCallback('asyncReadFile', function (data) {
+      log('asyncReadFile: [{}]', data);
+    }));
+  },
+  asyncWriteFile: function (parts) {
+    fs.writeFile(parts[1], parts.slice(2).join('|'), asyncCallback('asyncWriteFile'));
+  },
+  asyncAppendFile: function (parts) {
+    fs.appendFile(parts[1], parts.slice(2).join('|'), asyncCallback('asyncAppendFile'));
+  },
+  asyncStat: function (parts) {
+    fs.stat(parts[1], asyncCallback('asyncStat', function (st) {
+      log('asyncStat: size={} isFile={} isDirectory={}', st.size, st.isFile, st.isDirectory);
+    }));
+  },
+  asyncReaddir: function (parts) {
+    fs.readdir(parts[1], asyncCallback('asyncReaddir', function (entries) {
+      var names = [];
+      for (var i = 0; i < entries.length; i++) {
+        names.push(entries[i].name);
+      }
+      names.sort();
+      log('asyncReaddir: {}', names.join(','));
+    }));
+  },
+  asyncExists: function (parts) {
+    fs.exists(parts[1], function (exists) {
+      log('asyncExists: {}', exists);
+    });
+  },
+  asyncMkdir: function (parts) {
+    var cb = asyncCallback('asyncMkdir');
+    parts[2] === 'recursive' ? fs.mkdir(parts[1], {recursive: true}, cb) : fs.mkdir(parts[1], cb);
+  },
+  asyncUnlink: function (parts) {
+    fs.unlink(parts[1], asyncCallback('asyncUnlink'));
+  },
+  asyncRename: function (parts) {
+    fs.rename(parts[1], parts[2], asyncCallback('asyncRename'));
+  },
+  asyncRmdir: function (parts) {
+    var cb = asyncCallback('asyncRmdir');
+    parts[2] === 'recursive' ? fs.rmdir(parts[1], {recursive: true}, cb) : fs.rmdir(parts[1], cb);
+  },
+  asyncCopyFile: function (parts) {
+    fs.copyFile(parts[1], parts[2], asyncCallback('asyncCopyFile'));
+  },
+  asyncAccess: function (parts) {
+    var cb = asyncCallback('asyncAccess');
+    parts[2] ? fs.access(parts[1], parseInt(parts[2]), cb) : fs.access(parts[1], cb);
+  },
+  asyncRealpath: function (parts) {
+    fs.realpath(parts[1], asyncCallback('asyncRealpath', function (resolved) {
+      log('asyncRealpath: {}', resolved);
+    }));
+  },
+  asyncReadlink: function (parts) {
+    fs.readlink(parts[1], asyncCallback('asyncReadlink', function (target) {
+      log('asyncReadlink: {}', target);
+    }));
+  },
+
+  // Watch
+  watch: function (parts) {
+    var watcher = fs.watch(parts[1], function (eventType, filename) {
+      log('watch: {} {}', eventType, filename);
+    });
+    global._testWatcher = watcher;
+    log('watch: started');
+  },
+  watchClose: function () {
+    if (global._testWatcher) {
+      global._testWatcher.close();
+      log('watch: closed');
+    }
+  },
+  watchDir: function (parts) {
+    var watcher = fs.watch(parts[1], function (eventType, filename) {
+      log('watchDir: {} {}', eventType, filename);
+    });
+    global._testDirWatcher = watcher;
+    log('watchDir: started');
+  },
+  watchDirClose: function () {
+    if (global._testDirWatcher) {
+      global._testDirWatcher.close();
+      log('watchDir: closed');
+    }
+  },
+  watchNonExistent: function (parts) {
+    var w = fs.watch(parts[1], function (eventType, filename) {
+      log('watch: {} {}', eventType, filename);
+    });
+    log('watch: should not reach');
+  },
+
+  // Error cases: missing callback
+  asyncReadFileNoCallback: function (parts) {
+    fs.readFile(parts[1]);
+    log('asyncReadFile: should not reach');
+  },
+  asyncWriteFileNoCallback: function (parts) {
+    fs.writeFile(parts[1], parts.slice(2).join('|'));
+    log('asyncWriteFile: should not reach');
+  },
+  asyncStatNoCallback: function (parts) {
+    fs.stat(parts[1]);
+    log('asyncStat: should not reach');
+  },
+};
+
+defineRule('fileCmd', {
+  whenChanged: 'somedev/fileCmd',
+  then: function (cmd) {
+    var parts = cmd.split('|');
+    var op = parts[0];
+    var handler = syncOps[op] || asyncOps[op];
+
+    try {
+      if (handler) {
+        handler(parts);
+      }
+    } catch (e) {
+      log.error('caught error');
+    }
+  },
+});


### PR DESCRIPTION
## Что происходит; кому и зачем нужно:

Добавляет глобальный объект `fs` в движок правил wb-rules, реализующий файловый API в стиле Node.js. Это позволяет пользователям читать/писать файлы, работать с директориями, симлинками и следить за изменениями файлов прямо из скриптов правил — без внешних утилит и exec-вызовов.

Типичные сценарии:
- Чтение данных из sysfs (температура CPU, состояние GPIO)
- Запись конфигурации и логов
- Отслеживание изменений файлов через `fs.watch()`
- Работа с символическими ссылками и правами доступа

## Что поменялось для пользователей:

Появился глобальный объект `fs` со следующими функциями:

**Синхронные:**
- `fs.readFileSync(path)` — чтение файла (до 10 МБ)
- `fs.writeFileSync(path, data)` — запись файла
- `fs.appendFileSync(path, data)` — дозапись в файл
- `fs.unlinkSync(path)` — удаление файла
- `fs.mkdirSync(path [, {recursive}])` — создание директории
- `fs.rmdirSync(path [, {recursive}])` — удаление директории
- `fs.copyFileSync(src, dest)` — копирование файла (потоковое, сохраняет права)
- `fs.existsSync(path)` — проверка существования
- `fs.statSync(path)` — получение информации о файле
- `fs.readdirSync(path)` — список файлов в директории
- `fs.renameSync(oldPath, newPath)` — переименование/перемещение
- `fs.accessSync(path [, mode])` — проверка прав доступа
- `fs.realpathSync(path)` — разрешение симлинков
- `fs.readlinkSync(path)` — чтение цели симлинка

**Асинхронные** (с callback):
- `fs.readFile`, `fs.writeFile`, `fs.appendFile`, `fs.unlink`, `fs.mkdir`, `fs.rmdir`, `fs.copyFile`, `fs.stat`, `fs.readdir`, `fs.rename`, `fs.access`, `fs.realpath`, `fs.readlink`

**Наблюдение за файлами:**
- `fs.watch(path, callback)` — возвращает объект `{close()}`, callback вызывается при изменении файла

**Константы:**
- `fs.constants.F_OK`, `fs.constants.R_OK`, `fs.constants.W_OK`, `fs.constants.X_OK`

Лимит чтения файлов — 10 МБ. Защита от удаления корневых путей (`/`, `.`). Потоковое копирование через `io.Copy`.

## Как проверял/а:

- 75 unit-тестов на все функции (sync + async + error cases): `go test -run TestFile -v`
- Сборка deb-пакета (`WBDEV_TARGET=bullseye-arm64 wbdev cdeb`)
- Установка на контроллер WB, проверка демо-правила с мониторингом температуры CPU через sysfs
- `golangci-lint run` — без замечаний
- Все 191 существующих тестов проходят