### PR TITLE
getDevice/getControl: suppress errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.39.4) stable; urgency=medium
+
+  * getDevice/getControl: suppress errors
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 08 Apr 2026 17:00:00 +0400
+
 wb-rules (2.39.3) stable; urgency=medium
 
   * Add 'unixtime' control type support

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -1021,7 +1021,7 @@ func (engine *ESEngine) esGetDevice(ctx *ESContext) int {
 
 	errDevice := engine.GetDevice(name)
 	if errDevice != nil {
-		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("Error in getting device: %s", errDevice))
+		engine.Log(ENGINE_LOG_DEBUG, fmt.Sprintf("Error in getting device: %s", errDevice))
 		ctx.PushUndefined()
 		return 1
 	}
@@ -1061,7 +1061,7 @@ func (engine *ESEngine) esGetDevice(ctx *ESContext) int {
 
 func (engine *ESEngine) esGetControl(ctx *ESContext) int {
 	if ctx.GetTop() != 1 || !ctx.IsString(0) {
-		engine.Log(ENGINE_LOG_ERROR, "getDevice(): bad parameters")
+		engine.Log(ENGINE_LOG_ERROR, "getControl(): bad parameters")
 		return duktape.DUK_RET_ERROR
 	}
 
@@ -1069,7 +1069,7 @@ func (engine *ESEngine) esGetControl(ctx *ESContext) int {
 
 	ids := strings.Split(name, "/")
 	if len(ids) != 2 {
-		engine.Log(ENGINE_LOG_ERROR, "getDevice(): bad parameters: should be 'devID/cellID'")
+		engine.Log(ENGINE_LOG_ERROR, "getControl(): bad parameters: should be 'devID/cellID'")
 		return duktape.DUK_RET_ERROR
 	}
 	devID := ids[0]
@@ -1077,14 +1077,14 @@ func (engine *ESEngine) esGetControl(ctx *ESContext) int {
 
 	errDevice := engine.GetDevice(devID)
 	if errDevice != nil {
-		engine.Log(ENGINE_LOG_ERROR, fmt.Sprintf("Error in getting device: %s", errDevice))
+		engine.Log(ENGINE_LOG_DEBUG, fmt.Sprintf("Error in getting device: %s", errDevice))
 		ctx.PushUndefined()
 		return 1
 	}
 	devProxy := engine.GetDeviceProxy(devID)
 	ctrl := devProxy.getControl(ctrlID)
 	if ctrl == nil {
-		wbgong.Error.Printf("getControl(): no such control '%s'", ctrlID)
+		engine.Log(ENGINE_LOG_DEBUG, fmt.Sprintf("getControl(): no such control '%s'", ctrlID))
 		ctx.PushUndefined()
 		return 1
 	}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
getDevice/getControl возвращают undefined в случае если девайс/контрол не существует, это не есть ошибка, но сейчас в таком случае всегда пишется ошибка в журнал. Убираем в дебаг.

___________________________________
**Что поменялось для пользователей:**
нет ошибок в журнале

___________________________________
**Как проверял/а:**
на вб

