### PR TITLE
Fix garbled non-BMP characters in email notifications

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules (2.44.1) stable; urgency=medium
+
+  * Notify: fix garbled emoji (and other non-BMP characters) in sendEmail subject
+    and body by encoding them as proper UTF-8 base64 instead of Duktape's CESU-8
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 30 Jun 2026 19:00:00 +0400
+
 wb-rules (2.44.0) stable; urgency=medium
 
   * Notify: sendEmail/sendSMS/sendWebhook/sendTelegramMessage accept an optional

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -191,7 +191,7 @@ exports.sendEmail = function (to, subject, text, callback) {
     'To: ' + to + '\r\n' +
     'Subject: =?utf-8?B?' + _utf8ToBase64(subject) + '?=\r\n' +
     'Content-Type: text/plain; charset=utf-8\r\n' +
-    'Content-Transfer-Encoding: base64\n\n' +
+    'Content-Transfer-Encoding: base64\r\n\r\n' +
     _wrapBase64(_utf8ToBase64(text));
   runShellCommand('/usr/sbin/sendmail -t', {
     captureErrorOutput: true,

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -1,4 +1,4 @@
-/* global log, runShellCommand, debug, Duktape */
+/* global log, runShellCommand, debug */
 
 var _smsQueue = [],
   _smsBusy = false;
@@ -125,13 +125,78 @@ function _notifyDone(callback, err) {
   }
 }
 
+var _BASE64_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+// Encode a string as base64 of its UTF-8 bytes.
+//
+// Duktape keeps strings as CESU-8 internally, so Duktape.enc('base64', str)
+// (and passing a string straight to a shell command) yields invalid UTF-8 for
+// characters outside the BMP — e.g. emoji — which mail clients then render as
+// garbage. encodeURIComponent produces the correct UTF-8 byte sequence for
+// every code point (it combines surrogate pairs), which we base64-encode here.
+function _utf8ToBase64(str) {
+  var enc = encodeURIComponent(String(str));
+  var bytes = [];
+  var i = 0;
+  while (i < enc.length) {
+    if (enc.charAt(i) === '%') {
+      bytes.push(parseInt(enc.substr(i + 1, 2), 16));
+      i += 3;
+    } else {
+      bytes.push(enc.charCodeAt(i));
+      i += 1;
+    }
+  }
+
+  var out = '';
+  for (i = 0; i + 3 <= bytes.length; i += 3) {
+    var n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out +=
+      _BASE64_ALPHABET.charAt((n >> 18) & 63) +
+      _BASE64_ALPHABET.charAt((n >> 12) & 63) +
+      _BASE64_ALPHABET.charAt((n >> 6) & 63) +
+      _BASE64_ALPHABET.charAt(n & 63);
+  }
+  var rem = bytes.length - i;
+  if (rem === 1) {
+    var a = bytes[i] << 16;
+    out +=
+      _BASE64_ALPHABET.charAt((a >> 18) & 63) +
+      _BASE64_ALPHABET.charAt((a >> 12) & 63) +
+      '==';
+  } else if (rem === 2) {
+    var b = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    out +=
+      _BASE64_ALPHABET.charAt((b >> 18) & 63) +
+      _BASE64_ALPHABET.charAt((b >> 12) & 63) +
+      _BASE64_ALPHABET.charAt((b >> 6) & 63) +
+      '=';
+  }
+  return out;
+}
+
+// Split a base64 payload into 76-character lines per RFC 2045.
+function _wrapBase64(b64) {
+  var lines = [];
+  for (var i = 0; i < b64.length; i += 76) {
+    lines.push(b64.substr(i, 76));
+  }
+  return lines.join('\r\n');
+}
+
 exports.sendEmail = function (to, subject, text, callback) {
   log('sending email: {}', subject);
-  var base64subject = Duktape.enc('base64', subject);
+  var input =
+    'To: ' + to + '\r\n' +
+    'Subject: =?utf-8?B?' + _utf8ToBase64(subject) + '?=\r\n' +
+    'Content-Type: text/plain; charset=utf-8\r\n' +
+    'Content-Transfer-Encoding: base64\n\n' +
+    _wrapBase64(_utf8ToBase64(text));
   runShellCommand('/usr/sbin/sendmail -t', {
     captureErrorOutput: true,
     captureOutput: true,
-    input: 'To: {}\r\nSubject: =?utf-8?B?{}?=\r\nContent-Type: text/plain; charset=utf-8\n\n{}'.format(to, base64subject, text),
+    input: input,
     exitCallback: function exitCallback(exitCode, capturedOutput, capturedErrorOutput) {
       var err = null;
       if (exitCode != 0) {

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -216,6 +216,7 @@ exports.sendEmail = function (to, subject, text, callback) {
   var input =
     'To: ' + to + '\r\n' +
     'Subject: =?utf-8?B?' + _utf8ToBase64(subject) + '?=\r\n' +
+    'MIME-Version: 1.0\r\n' +
     'Content-Type: text/plain; charset=utf-8\r\n' +
     'Content-Transfer-Encoding: base64\r\n\r\n' +
     _wrapBase64(_utf8ToBase64(text));

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -212,6 +212,14 @@ function _wrapBase64(b64) {
 }
 
 exports.sendEmail = function (to, subject, text, callback) {
+  to = String(to);
+  // 'to' is the only field placed into a header verbatim (subject and body are
+  // base64-encoded), so a CR/LF in it would break the header/body boundary and
+  // allow header injection. Reject such values instead of building the message.
+  if (/[\r\n]/.test(to)) {
+    _notifyDone(callback, new Error("error sending email: 'to' must not contain CR or LF"));
+    return;
+  }
   log('sending email: {}', subject);
   var input =
     'To: ' + to + '\r\n' +

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -128,6 +128,32 @@ function _notifyDone(callback, err) {
 var _BASE64_ALPHABET =
   'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
+// Replace unpaired UTF-16 surrogates with U+FFFD. encodeURIComponent (used by
+// _utf8ToBase64) throws URIError on malformed UTF-16 such as a lone surrogate,
+// which would otherwise crash sendEmail; sanitizing keeps notifications working.
+function _sanitizeSurrogates(str) {
+  var out = '';
+  for (var i = 0; i < str.length; i++) {
+    var c = str.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      // high surrogate: valid only when immediately followed by a low surrogate
+      var next = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += str.charAt(i) + str.charAt(i + 1);
+        i++;
+      } else {
+        out += '�';
+      }
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      // lone low surrogate
+      out += '�';
+    } else {
+      out += str.charAt(i);
+    }
+  }
+  return out;
+}
+
 // Encode a string as base64 of its UTF-8 bytes.
 //
 // Duktape keeps strings as CESU-8 internally, so Duktape.enc('base64', str)
@@ -136,7 +162,7 @@ var _BASE64_ALPHABET =
 // garbage. encodeURIComponent produces the correct UTF-8 byte sequence for
 // every code point (it combines surrogate pairs), which we base64-encode here.
 function _utf8ToBase64(str) {
-  var enc = encodeURIComponent(String(str));
+  var enc = encodeURIComponent(_sanitizeSurrogates(String(str)));
   var bytes = [];
   var i = 0;
   while (i < enc.length) {

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -177,6 +177,7 @@ function _utf8ToBase64(str) {
 
   var out = '';
   for (i = 0; i + 3 <= bytes.length; i += 3) {
+    // eslint-disable-next-line security/detect-object-injection
     var n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
     out +=
       _BASE64_ALPHABET.charAt((n >> 18) & 63) +
@@ -186,12 +187,14 @@ function _utf8ToBase64(str) {
   }
   var rem = bytes.length - i;
   if (rem === 1) {
+    // eslint-disable-next-line security/detect-object-injection
     var a = bytes[i] << 16;
     out +=
       _BASE64_ALPHABET.charAt((a >> 18) & 63) +
       _BASE64_ALPHABET.charAt((a >> 12) & 63) +
       '==';
   } else if (rem === 2) {
+    // eslint-disable-next-line security/detect-object-injection
     var b = (bytes[i] << 16) | (bytes[i + 1] << 8);
     out +=
       _BASE64_ALPHABET.charAt((b >> 18) & 63) +

--- a/wbrules/rule_notify_email_test.go
+++ b/wbrules/rule_notify_email_test.go
@@ -34,7 +34,7 @@ func (s *RuleNotifyEmailSuite) TestEmail() {
 		"tst -> /devices/test_email/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test subject] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\n\nTest text] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCB0ZXh0] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [email send status: ok] (QoS 1)",
 	)
 }
@@ -48,7 +48,7 @@ func (s *RuleNotifyEmailSuite) TestEmailError() {
 		"tst -> /devices/test_email/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test subject] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\n\nTest text] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCB0ZXh0] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [email send status: error] (QoS 1)",
 	)
 }
@@ -63,7 +63,7 @@ func (s *RuleNotifyEmailSuite) TestEmailErrorWithoutCallback() {
 		"tst -> /devices/test_email/controls/send_quoted/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test \"subject\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\n\nTest \"text\" 'single'] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
 		"wbrules-log -> /wbrules/log/error: [error sending email:\nstdout\nstderr] (QoS 1)",
 	)
 }
@@ -77,7 +77,26 @@ func (s *RuleNotifyEmailSuite) TestEmailWithQuotes() {
 		"tst -> /devices/test_email/controls/send_quoted/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test \"subject\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\n\nTest \"text\" 'single'] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
+	)
+}
+
+// Emoji (and any other character outside the Basic Multilingual Plane) must be
+// transmitted as proper UTF-8. Duktape stores strings as CESU-8 internally, so
+// the subject/body are base64-encoded from their real UTF-8 bytes rather than
+// handed to the shell (or Duktape.enc) directly. Note that the "sending email:"
+// log line below still shows the CESU-8 bytes of the emoji — that is a separate
+// cosmetic quirk of logging through Duktape, not of the message we send.
+func (s *RuleNotifyEmailSuite) TestEmailEmoji() {
+	s.setErrorCode(0)
+
+	s.publish("/devices/test_email/controls/send_emoji/on", "1", "test_email/send_emoji")
+	s.VerifyUnordered(
+		"driver -> /devices/test_email/controls/send_emoji: [1] (QoS 1)",
+		"tst -> /devices/test_email/controls/send_emoji/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending email: \xed\xa0\xbc\xed\xbf\xa0 тема] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?8J+PoCDRgtC10LzQsA==?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\n8J+PoCDRgtC10LrRgdGC] (QoS 1)",
 	)
 }
 

--- a/wbrules/rule_notify_email_test.go
+++ b/wbrules/rule_notify_email_test.go
@@ -34,7 +34,7 @@ func (s *RuleNotifyEmailSuite) TestEmail() {
 		"tst -> /devices/test_email/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test subject] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCB0ZXh0] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCB0ZXh0] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [email send status: ok] (QoS 1)",
 	)
 }
@@ -48,7 +48,7 @@ func (s *RuleNotifyEmailSuite) TestEmailError() {
 		"tst -> /devices/test_email/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test subject] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCB0ZXh0] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCB0ZXh0] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [email send status: error] (QoS 1)",
 	)
 }
@@ -63,7 +63,7 @@ func (s *RuleNotifyEmailSuite) TestEmailErrorWithoutCallback() {
 		"tst -> /devices/test_email/controls/send_quoted/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test \"subject\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
 		"wbrules-log -> /wbrules/log/error: [error sending email:\nstdout\nstderr] (QoS 1)",
 	)
 }
@@ -77,7 +77,7 @@ func (s *RuleNotifyEmailSuite) TestEmailWithQuotes() {
 		"tst -> /devices/test_email/controls/send_quoted/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test \"subject\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
 	)
 }
 
@@ -96,7 +96,7 @@ func (s *RuleNotifyEmailSuite) TestEmailEmoji() {
 		"tst -> /devices/test_email/controls/send_emoji/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: \xed\xa0\xbc\xed\xbf\xa0 тема] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?8J+PoCDRgtC10LzQsA==?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\n8J+PoCDRgtC10LrRgdGC] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?8J+PoCDRgtC10LzQsA==?=\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\n8J+PoCDRgtC10LrRgdGC] (QoS 1)",
 	)
 }
 
@@ -114,7 +114,7 @@ func (s *RuleNotifyEmailSuite) TestEmailLoneSurrogate() {
 		"tst -> /devices/test_email/controls/send_lone_surrogate/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: a\xed\xa0\x80b] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?Ye+/vWI=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\neO+/vXk=] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?Ye+/vWI=?=\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\neO+/vXk=] (QoS 1)",
 	)
 }
 

--- a/wbrules/rule_notify_email_test.go
+++ b/wbrules/rule_notify_email_test.go
@@ -118,6 +118,17 @@ func (s *RuleNotifyEmailSuite) TestEmailLoneSurrogate() {
 	)
 }
 
+// A CR/LF in 'to' must be rejected before the message is built, so it cannot be
+// used to inject extra headers (e.g. a hidden Bcc). No sendmail command is run.
+func (s *RuleNotifyEmailSuite) TestEmailHeaderInjection() {
+	s.publish("/devices/test_email/controls/send_header_injection/on", "1", "test_email/send_header_injection")
+	s.VerifyUnordered(
+		"driver -> /devices/test_email/controls/send_header_injection: [1] (QoS 1)",
+		"tst -> /devices/test_email/controls/send_header_injection/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [email send status: error sending email: 'to' must not contain CR or LF] (QoS 1)",
+	)
+}
+
 func TestNotifyEmailSuite(t *testing.T) {
 	testutils.RunSuites(t,
 		new(RuleNotifyEmailSuite),

--- a/wbrules/rule_notify_email_test.go
+++ b/wbrules/rule_notify_email_test.go
@@ -34,7 +34,7 @@ func (s *RuleNotifyEmailSuite) TestEmail() {
 		"tst -> /devices/test_email/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test subject] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCB0ZXh0] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCB0ZXh0] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [email send status: ok] (QoS 1)",
 	)
 }
@@ -48,7 +48,7 @@ func (s *RuleNotifyEmailSuite) TestEmailError() {
 		"tst -> /devices/test_email/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test subject] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCB0ZXh0] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCBzdWJqZWN0?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCB0ZXh0] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [email send status: error] (QoS 1)",
 	)
 }
@@ -63,7 +63,7 @@ func (s *RuleNotifyEmailSuite) TestEmailErrorWithoutCallback() {
 		"tst -> /devices/test_email/controls/send_quoted/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test \"subject\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
 		"wbrules-log -> /wbrules/log/error: [error sending email:\nstdout\nstderr] (QoS 1)",
 	)
 }
@@ -77,7 +77,7 @@ func (s *RuleNotifyEmailSuite) TestEmailWithQuotes() {
 		"tst -> /devices/test_email/controls/send_quoted/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: Test \"subject\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?VGVzdCAic3ViamVjdCIgJ3NpbmdsZSc=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\nVGVzdCAidGV4dCIgJ3NpbmdsZSc=] (QoS 1)",
 	)
 }
 
@@ -96,7 +96,7 @@ func (s *RuleNotifyEmailSuite) TestEmailEmoji() {
 		"tst -> /devices/test_email/controls/send_emoji/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending email: \xed\xa0\xbc\xed\xbf\xa0 тема] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?8J+PoCDRgtC10LzQsA==?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\n\n8J+PoCDRgtC10LrRgdGC] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?8J+PoCDRgtC10LzQsA==?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\n8J+PoCDRgtC10LrRgdGC] (QoS 1)",
 	)
 }
 

--- a/wbrules/rule_notify_email_test.go
+++ b/wbrules/rule_notify_email_test.go
@@ -100,6 +100,24 @@ func (s *RuleNotifyEmailSuite) TestEmailEmoji() {
 	)
 }
 
+// Malformed UTF-16 (a lone surrogate) makes encodeURIComponent throw, which
+// would crash sendEmail. Such characters are sanitized to U+FFFD so the message
+// still goes out. The "sending email:" log line shows the lone surrogate's
+// CESU-8 bytes (ED A0 80), while the actual subject/body carry the sanitized
+// U+FFFD (EF BF BD) — Ye+/vWI= / eO+/vXk= in base64.
+func (s *RuleNotifyEmailSuite) TestEmailLoneSurrogate() {
+	s.setErrorCode(0)
+
+	s.publish("/devices/test_email/controls/send_lone_surrogate/on", "1", "test_email/send_lone_surrogate")
+	s.VerifyUnordered(
+		"driver -> /devices/test_email/controls/send_lone_surrogate: [1] (QoS 1)",
+		"tst -> /devices/test_email/controls/send_lone_surrogate/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending email: a\xed\xa0\x80b] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: /usr/sbin/sendmail -t] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: To: me@example.org\r\nSubject: =?utf-8?B?Ye+/vWI=?=\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\neO+/vXk=] (QoS 1)",
+	)
+}
+
 func TestNotifyEmailSuite(t *testing.T) {
 	testutils.RunSuites(t,
 		new(RuleNotifyEmailSuite),

--- a/wbrules/testrules_email_commands.js
+++ b/wbrules/testrules_email_commands.js
@@ -1,3 +1,5 @@
+/* global log, Notify */
+
 global.__proto__.runShellCommand = function (command, options) {
   log('run command: {}', command);
   if (options.input) {

--- a/wbrules/testrules_email_commands.js
+++ b/wbrules/testrules_email_commands.js
@@ -24,6 +24,9 @@ defineVirtualDevice('test_email', {
     send_emoji: {
       type: 'pushbutton',
     },
+    send_lone_surrogate: {
+      type: 'pushbutton',
+    },
   },
 });
 
@@ -47,5 +50,13 @@ defineRule({
   whenChanged: 'test_email/send_emoji',
   then: function () {
     Notify.sendEmail('me@example.org', '🏠 тема', '🏠 текст');
+  },
+});
+
+defineRule({
+  whenChanged: 'test_email/send_lone_surrogate',
+  then: function () {
+    // malformed UTF-16 (lone surrogate) must not crash sendEmail
+    Notify.sendEmail('me@example.org', 'a\uD800b', 'x\uD800y');
   },
 });

--- a/wbrules/testrules_email_commands.js
+++ b/wbrules/testrules_email_commands.js
@@ -21,6 +21,9 @@ defineVirtualDevice('test_email', {
     send_quoted: {
       type: 'pushbutton',
     },
+    send_emoji: {
+      type: 'pushbutton',
+    },
   },
 });
 
@@ -37,5 +40,12 @@ defineRule({
   whenChanged: 'test_email/send_quoted',
   then: function () {
     Notify.sendEmail('me@example.org', 'Test "subject" \'single\'', 'Test "text" \'single\'');
+  },
+});
+
+defineRule({
+  whenChanged: 'test_email/send_emoji',
+  then: function () {
+    Notify.sendEmail('me@example.org', '🏠 тема', '🏠 текст');
   },
 });

--- a/wbrules/testrules_email_commands.js
+++ b/wbrules/testrules_email_commands.js
@@ -27,6 +27,9 @@ defineVirtualDevice('test_email', {
     send_lone_surrogate: {
       type: 'pushbutton',
     },
+    send_header_injection: {
+      type: 'pushbutton',
+    },
   },
 });
 
@@ -58,5 +61,15 @@ defineRule({
   then: function () {
     // malformed UTF-16 (lone surrogate) must not crash sendEmail
     Notify.sendEmail('me@example.org', 'a\uD800b', 'x\uD800y');
+  },
+});
+
+defineRule({
+  whenChanged: 'test_email/send_header_injection',
+  then: function () {
+    // a CR/LF in 'to' must be rejected, not turned into extra headers
+    Notify.sendEmail('me@example.org\r\nBcc: evil@example.org', 'subj', 'body', function (err) {
+      log('email send status: {}', err ? err.message : 'ok');
+    });
   },
 });

--- a/wbrules/testrules_sms_commands.js
+++ b/wbrules/testrules_sms_commands.js
@@ -1,3 +1,5 @@
+/* global log, Notify */
+
 var exitCodes = [];
 
 global.__proto__.runShellCommand = function (command, options) {

--- a/wbrules/testrules_tg_commands.js
+++ b/wbrules/testrules_tg_commands.js
@@ -1,3 +1,5 @@
+/* global log, Notify */
+
 global.__proto__.runShellCommand = function (command, options) {
   log('run command: {}', command);
   if (options.input) {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Символы вне диапазона BMP (основная многоязычная плоскость) отображались в почтовом клиенте как мусор. Например `Notify.sendEmail('me@gmail.com', '🏠 тема', '🏠 текст');`. Сейчас кодируются и передаются в base64.
___________________________________
**Что поменялось для пользователей:**
В нотификациях можно использовать любые символы.

___________________________________
**Как проверял/а:**
на вб

