### PR TITLE
Fix memory leak with startTicker

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.44.2) stable; urgency=medium
+
+  * Fix memory leak with startTicker
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 01 Jul 2026 17:00:00 +0400
+
 wb-rules (2.44.1) stable; urgency=medium
 
   * Notify: fix garbled emoji (and other non-BMP characters) in sendEmail subject

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -1073,6 +1073,12 @@ func (engine *RuleEngine) storeRuleTimer(rule *Rule, timerName string) {
 	list, found := engine.timerRules[timerName]
 	if !found {
 		list = make([]*Rule, 0, ENGINE_CONTROL_RULES_CAPACITY)
+	} else {
+		for _, item := range list {
+			if item == rule {
+				return
+			}
+		}
 	}
 	engine.timerRules[timerName] = append(list, rule)
 }

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -461,6 +461,8 @@ func (engine *ESEngine) runTimerCleanups(ctx *ESContext) {
 		for _, id := range ids {
 			engine.StopTimerByIndex(id)
 		}
+
+		delete(engine.ctxTimers, ctx)
 	}
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В правилах с `startTicker` и `defineRule` срабатывающем по `timers[...].firing` наблюдается утечка памяти

___________________________________
**Что поменялось для пользователей:**
нет утечки при использовании `startTicker`

___________________________________
**Как проверял/а:**
на вб

