### PR TITLE
StorableObject: hide technical _psself field from Object.keys()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules (2.44.3) stable; urgency=medium
+
+  * StorableObject: hide technical _psself field from Object.keys() and
+    Object.keys().forEach(), matching the behavior already present in for-in
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 03 Jul 2026 15:10:00 +0400
+
 wb-rules (2.44.2) stable; urgency=medium
 
   * Fix memory leak with startTicker

--- a/modules/wb-alarms.js
+++ b/modules/wb-alarms.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, dev, getDevice, log, readConfig */
+/* global defineVirtualDevice, defineRule, dev, getDevice, log, readConfig, _WbRules */
 
 var Notify = require('wb-notify');
 

--- a/modules/wb-alarms.js
+++ b/modules/wb-alarms.js
@@ -1,4 +1,4 @@
-/* global log */
+/* global defineVirtualDevice, defineRule, dev, getDevice, log, readConfig */
 
 var Notify = require('wb-notify');
 

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -255,7 +255,7 @@ exports.sendSMS = function (to, text, command, callback) {
   var doneCallback = function (exitCode, capturedOutput, capturedErrorOutput) {
     _smsBusy = false;
     var err = null;
-    if (exitCode != 0) {
+    if (exitCode !== 0) {
       err = new Error('error sending sms:\n' + capturedOutput + '\n' + capturedErrorOutput);
     }
     _advanceSmsQueue();

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -237,7 +237,7 @@ exports.sendEmail = function (to, subject, text, callback) {
     input: input,
     exitCallback: function exitCallback(exitCode, capturedOutput, capturedErrorOutput) {
       var err = null;
-      if (exitCode != 0) {
+      if (exitCode !== 0) {
         err = new Error('error sending email:\n' + capturedOutput + '\n' + capturedErrorOutput);
       }
       _notifyDone(callback, err);

--- a/sample1.js
+++ b/sample1.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, dev, log, runShellCommand, startTicker */
+
 defineVirtualDevice('relayClicker', {
   title: 'Relay Clicker',
   cells: {

--- a/sample1.js
+++ b/sample1.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, dev, log, runShellCommand, startTicker */
+/* global defineVirtualDevice, defineRule, dev, log, runShellCommand, startTicker, timers */
 
 defineVirtualDevice('relayClicker', {
   title: 'Relay Clicker',

--- a/samplerules.js
+++ b/samplerules.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineAlias, defineVirtualDevice, defineRule, log */
 
 defineVirtualDevice('stabSettings', {
   title: 'Stabilization Settings',

--- a/samplerules.js
+++ b/samplerules.js
@@ -1,4 +1,4 @@
-/* global defineAlias, defineVirtualDevice, defineRule, log */
+/* global defineAlias, defineVirtualDevice, defineRule, startTimer, runShellCommand, log */
 
 defineVirtualDevice('stabSettings', {
   title: 'Stabilization Settings',

--- a/samplerules.js
+++ b/samplerules.js
@@ -1,4 +1,4 @@
-/* global defineAlias, defineVirtualDevice, defineRule, startTimer, runShellCommand, log */
+/* global defineAlias, defineVirtualDevice, defineRule, cron, startTimer, runShellCommand, log, timers */
 
 defineVirtualDevice('stabSettings', {
   title: 'Stabilization Settings',

--- a/samplerules.js
+++ b/samplerules.js
@@ -1,4 +1,4 @@
-/* global defineAlias, defineVirtualDevice, defineRule, cron, startTimer, runShellCommand, log, timers */
+/* global defineAlias, defineVirtualDevice, defineRule, cron, startTimer, startTicker, runShellCommand, log, timers */
 
 defineVirtualDevice('stabSettings', {
   title: 'Stabilization Settings',

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -423,6 +423,11 @@ global.StorableObject = function (obj, ps, pskey) {
       keys.splice(keys.indexOf('_psself'), 1);
       return keys;
     },
+    ownKeys: function (o) {
+      var keys = Object.keys(o);
+      keys.splice(keys.indexOf('_psself'), 1);
+      return keys;
+    },
   });
 
   p._psself = p;

--- a/wbrules/persistent_storage_test.go
+++ b/wbrules/persistent_storage_test.go
@@ -51,6 +51,8 @@ func (s *PersistentStorageSuite) TestPersistentStorage() {
 		"driver -> /devices/vdev/controls/write: [1] (QoS 1, retained)",
 		"[info] pure object is not created",
 		"[info] pure subobject is not created",
+		"[info] for-in keys: name,foo,baz,sub",
+		"[info] Object.keys: name,foo,baz,sub",
 		"[info] write objects 42, \"HelloWorld\", {\"name\":\"MyObj\",\"foo\":\"bar\",\"baz\":84,\"sub\":{\"hello\":\"world\"}}",
 	)
 }

--- a/wbrules/testrules.js
+++ b/wbrules/testrules.js
@@ -1,4 +1,4 @@
-/* global defineAlias, defineVirtualDevice, defineRule, log, publish */
+/* global defineAlias, defineVirtualDevice, defineRule, startTimer, log, publish */
 
 if (
   (function () {

--- a/wbrules/testrules.js
+++ b/wbrules/testrules.js
@@ -1,4 +1,4 @@
-/* global defineAlias, defineVirtualDevice, defineRule, dev, startTimer, log, publish */
+/* global defineAlias, defineVirtualDevice, defineRule, dev, startTimer, log, publish, timers */
 
 if (
   (function () {
@@ -113,7 +113,7 @@ defineAlias('tempx', 'somedev/tempx');
 defineRule('cellChange2', {
   whenChanged: ['somedev/foobarbaz', 'tempx' /* an alias */, 'somedev/abutton'],
   then: function (newValue, devName, cellName) {
-    if (arguments.length != 3) throw new Error('invalid arguments for then');
+    if (arguments.length !== 3) throw new Error('invalid arguments for then');
     var v = dev[devName][cellName];
     if (v !== newValue)
       throw new Error(
@@ -153,7 +153,7 @@ defineRule('funcValueChange3', {
     return timers.funcValueChange3.firing;
   },
   then: function (newValue) {
-    if (arguments.length != 1) throw new Error('invalid arguments for then');
+    if (arguments.length !== 1) throw new Error('invalid arguments for then');
     log('funcValueChange3: {} ({})', newValue, typeof newValue);
   },
 });

--- a/wbrules/testrules.js
+++ b/wbrules/testrules.js
@@ -1,4 +1,4 @@
-/* global defineAlias, defineVirtualDevice, defineRule, startTimer, log, publish */
+/* global defineAlias, defineVirtualDevice, defineRule, dev, startTimer, log, publish */
 
 if (
   (function () {
@@ -101,7 +101,7 @@ defineRule('sendmqtt', {
 defineRule('cellChange1', {
   whenChanged: 'somedev/foobarbaz',
   then: function (newValue, devName, cellName) {
-    if (arguments.length != 3) throw new Error('invalid arguments for then');
+    if (arguments.length !== 3) throw new Error('invalid arguments for then');
     var v = dev[devName][cellName];
     if (v !== newValue) throw new Error('bad newValue! ' + newValue);
     log('cellChange1: {}/{}={} ({})', devName, cellName, v, typeof v);
@@ -129,7 +129,7 @@ defineRule('funcValueChange', {
     return dev.somedev.cellforfunc > 3;
   },
   then: function (newValue, devName, cellName) {
-    if (arguments.length != 1) throw new Error('invalid arguments for then');
+    if (arguments.length !== 1) throw new Error('invalid arguments for then');
     log('funcValueChange: {} ({})', newValue, typeof newValue);
   },
 });

--- a/wbrules/testrules.js
+++ b/wbrules/testrules.js
@@ -1,4 +1,4 @@
-/* global defineAlias, defineVirtualDevice, defineRule, log */
+/* global defineAlias, defineVirtualDevice, defineRule, log, publish */
 
 if (
   (function () {

--- a/wbrules/testrules.js
+++ b/wbrules/testrules.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineAlias, defineVirtualDevice, defineRule, log */
 
 if (
   (function () {

--- a/wbrules/testrules_cellchanges.js
+++ b/wbrules/testrules_cellchanges.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log */
+/* global defineVirtualDevice, defineRule, dev, log */
 
 defineVirtualDevice('cellch', {
   title: 'Cell Change Test',

--- a/wbrules/testrules_cellchanges.js
+++ b/wbrules/testrules_cellchanges.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 defineVirtualDevice('cellch', {
   title: 'Cell Change Test',
   cells: {

--- a/wbrules/testrules_command.js
+++ b/wbrules/testrules_command.js
@@ -1,4 +1,4 @@
-/* global defineRule, log, runShellCommand */
+/* global defineRule, dev, log, runShellCommand */
 
 defineRule('runCommand', {
   whenChanged: 'somedev/cmd',

--- a/wbrules/testrules_command.js
+++ b/wbrules/testrules_command.js
@@ -30,7 +30,7 @@ defineRule('runCommandWithOutput', {
       exitCallback: function (exitCode, capturedOutput, capturedErrorOutput) {
         log('exit({}): {}', exitCode, cmd);
         displayOutput('output: ', capturedOutput);
-        if (exitCode != 0) displayOutput('error: ', capturedErrorOutput);
+        if (exitCode !== 0) displayOutput('error: ', capturedErrorOutput);
       },
     };
     var p = cmd.indexOf('!');

--- a/wbrules/testrules_command.js
+++ b/wbrules/testrules_command.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineRule, log, runShellCommand */
 
 defineRule('runCommand', {
   whenChanged: 'somedev/cmd',

--- a/wbrules/testrules_controls_api.js
+++ b/wbrules/testrules_controls_api.js
@@ -1,3 +1,5 @@
+/* global defineRule, defineVirtualDevice, getDevice, log */
+
 var ctrlID = 'wrCtrlID';
 
 defineRule({

--- a/wbrules/testrules_cron.js
+++ b/wbrules/testrules_cron.js
@@ -1,3 +1,5 @@
+/* global defineRule, cron, log */
+
 defineRule('crontest_hourly', {
   when: cron('@hourly'),
   then: function () {

--- a/wbrules/testrules_cron_changed.js
+++ b/wbrules/testrules_cron_changed.js
@@ -1,3 +1,5 @@
+/* global defineRule, cron, log */
+
 defineRule('crontest_hourly', {
   when: cron('@hourly'),
   then: function () {

--- a/wbrules/testrules_defhelper.js
+++ b/wbrules/testrules_defhelper.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log */
+/* global defineVirtualDevice, defineRule, dev, log */
 
 // When a rule is defined inside a module the editor must use the
 // topmost stack frame in the rule file to determine the location of

--- a/wbrules/testrules_defhelper.js
+++ b/wbrules/testrules_defhelper.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineVirtualDevice, defineRule, log */
 
 // When a rule is defined inside a module the editor must use the
 // topmost stack frame in the rule file to determine the location of

--- a/wbrules/testrules_email_commands.js
+++ b/wbrules/testrules_email_commands.js
@@ -1,4 +1,4 @@
-/* global log, Notify */
+/* global defineVirtualDevice, defineRule, log, Notify */
 
 global.__proto__.runShellCommand = function (command, options) {
   log('run command: {}', command);

--- a/wbrules/testrules_email_commands.js
+++ b/wbrules/testrules_email_commands.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log, Notify */
+/* global defineVirtualDevice, defineRule, dev, log, Notify */
 
 global.__proto__.runShellCommand = function (command, options) {
   log('run command: {}', command);

--- a/wbrules/testrules_isolation_1.js
+++ b/wbrules/testrules_isolation_1.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 defineVirtualDevice('vdev', {
   title: 'VDev',
   cells: {

--- a/wbrules/testrules_isolation_2.js
+++ b/wbrules/testrules_isolation_2.js
@@ -1,3 +1,5 @@
+/* global defineRule, log */
+
 var v = 42;
 
 defineRule('isolated_rule', {

--- a/wbrules/testrules_localbutton.js
+++ b/wbrules/testrules_localbutton.js
@@ -1,3 +1,5 @@
+/* global defineRule, defineVirtualDevice, log */
+
 defineVirtualDevice('buttons', {
   title: 'Button Test',
   cells: {

--- a/wbrules/testrules_locations.js
+++ b/wbrules/testrules_locations.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineRule */
 
 // The location of device "misc" is testrules_locations.js:4
 defineSomeDevice('misc');

--- a/wbrules/testrules_locations.js
+++ b/wbrules/testrules_locations.js
@@ -1,4 +1,4 @@
-/* global defineRule */
+/* global defineRule, dev, log */
 
 // The location of device "misc" is testrules_locations.js:4
 defineSomeDevice('misc');

--- a/wbrules/testrules_locations_changed.js
+++ b/wbrules/testrules_locations_changed.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineRule, log */
 
 // The location of device "misc" is testrules_locations.js:4
 defineSomeDevice('miscNew');

--- a/wbrules/testrules_locations_changed.js
+++ b/wbrules/testrules_locations_changed.js
@@ -1,4 +1,4 @@
-/* global defineRule, log */
+/* global defineRule, dev, log */
 
 // The location of device "misc" is testrules_locations.js:4
 defineSomeDevice('miscNew');

--- a/wbrules/testrules_log.js
+++ b/wbrules/testrules_log.js
@@ -1,3 +1,5 @@
+/* global log */
+
 global.__proto__.testLog = function testLog() {
   log('log()');
   debug('debug()');

--- a/wbrules/testrules_log.js
+++ b/wbrules/testrules_log.js
@@ -1,4 +1,4 @@
-/* global log */
+/* global log, debug */
 
 global.__proto__.testLog = function testLog() {
   log('log()');

--- a/wbrules/testrules_loopback.js
+++ b/wbrules/testrules_loopback.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, getControl, log */
+
 defineVirtualDevice('loopback', {
   cells: {
     gauge: {

--- a/wbrules/testrules_meta.js
+++ b/wbrules/testrules_meta.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, getDevice, log */
+
 function cellSpec(devName, cellName) {
   return devName === undefined ? '(no cell)' : '{}/{}'.format(devName, cellName);
 }

--- a/wbrules/testrules_meta.js
+++ b/wbrules/testrules_meta.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, getDevice, log */
+/* global defineVirtualDevice, defineRule, dev, getDevice, log */
 
 function cellSpec(devName, cellName) {
   return devName === undefined ? '(no cell)' : '{}/{}'.format(devName, cellName);

--- a/wbrules/testrules_modules.js
+++ b/wbrules/testrules_modules.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 defineVirtualDevice('test', {
   cells: {
     helloworld: {

--- a/wbrules/testrules_modules_2.js
+++ b/wbrules/testrules_modules_2.js
@@ -1,3 +1,5 @@
+/* global defineRule, log */
+
 defineRule('multiple_require', {
   whenChanged: 'test/multifile',
   then: function () {

--- a/wbrules/testrules_opt.js
+++ b/wbrules/testrules_opt.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineRule, log */
 
 var asSoonAsCount = 0,
   whenCount = 0,

--- a/wbrules/testrules_opt.js
+++ b/wbrules/testrules_opt.js
@@ -1,4 +1,4 @@
-/* global defineRule, log */
+/* global defineRule, dev, log */
 
 var asSoonAsCount = 0,
   whenCount = 0,

--- a/wbrules/testrules_persistent.js
+++ b/wbrules/testrules_persistent.js
@@ -71,6 +71,14 @@ defineRule('testPersistentGlobalWrite', {
       hello: 'world',
     });
 
+    // technical _psself field must not leak into enumeration
+    var forInKeys = [];
+    for (var k in obj) {
+      forInKeys.push(k);
+    }
+    log('for-in keys: ' + forInKeys.join(','));
+    log('Object.keys: ' + Object.keys(obj).join(','));
+
     log(
       'write objects ' +
         JSON.stringify(ps['key1']) +

--- a/wbrules/testrules_persistent.js
+++ b/wbrules/testrules_persistent.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineVirtualDevice, defineRule, log, PersistentStorage, StorableObject */
 
 defineVirtualDevice('vdev', {
   cells: {

--- a/wbrules/testrules_persistent_2.js
+++ b/wbrules/testrules_persistent_2.js
@@ -1,3 +1,5 @@
+/* global defineRule, log, PersistentStorage */
+
 defineRule('testPersistentGlobalRead', {
   whenChanged: ['vdev/read'],
   then: function () {

--- a/wbrules/testrules_read_config.js
+++ b/wbrules/testrules_read_config.js
@@ -1,3 +1,5 @@
+/* global defineRule, readConfig, log */
+
 defineRule('readSampleConfig', {
   whenChanged: 'somedev/readSampleConfig',
   then: function (path) {

--- a/wbrules/testrules_readonly.js
+++ b/wbrules/testrules_readonly.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice */
+
 defineVirtualDevice('roCells', {
   title: 'Readonly Cell Test',
   cells: {

--- a/wbrules/testrules_reload_1.js
+++ b/wbrules/testrules_reload_1.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 defineVirtualDevice('vdev0', {
   title: 'VDev0',
   cells: {

--- a/wbrules/testrules_reload_2.js
+++ b/wbrules/testrules_reload_2.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 var devCells = {
   someCell: {
     type: 'switch',

--- a/wbrules/testrules_reload_2.js
+++ b/wbrules/testrules_reload_2.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log */
+/* global defineAlias, defineVirtualDevice, defineRule, dev, log */
 
 var devCells = {
   someCell: {

--- a/wbrules/testrules_reload_2_changed.js
+++ b/wbrules/testrules_reload_2_changed.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, defineAlias, log */
+
 var devCells = {
   someCell: {
     type: 'switch',

--- a/wbrules/testrules_reload_2_changed.js
+++ b/wbrules/testrules_reload_2_changed.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, defineAlias, log */
+/* global defineVirtualDevice, defineRule, defineAlias, dev, log */
 
 var devCells = {
   someCell: {

--- a/wbrules/testrules_reload_3.js
+++ b/wbrules/testrules_reload_3.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log */
+/* global defineVirtualDevice, defineRule, dev, log */
 
 defineVirtualDevice('testNulledControl', {
   cells: {

--- a/wbrules/testrules_reload_3.js
+++ b/wbrules/testrules_reload_3.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 defineVirtualDevice('testNulledControl', {
   cells: {
     pers_text: {

--- a/wbrules/testrules_reload_3_changed.js
+++ b/wbrules/testrules_reload_3_changed.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 // the same code as in testrules_reload_3.js,
 // but it should cause script reloading
 

--- a/wbrules/testrules_reload_3_changed.js
+++ b/wbrules/testrules_reload_3_changed.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log */
+/* global defineVirtualDevice, defineRule, dev, log */
 
 // the same code as in testrules_reload_3.js,
 // but it should cause script reloading

--- a/wbrules/testrules_rule_controls.js
+++ b/wbrules/testrules_rule_controls.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, disableRule, enableRule, runRule, log */
+
 defineVirtualDevice('ctrltest', {
   cells: {
     disable: {

--- a/wbrules/testrules_rule_redefinition.js
+++ b/wbrules/testrules_rule_redefinition.js
@@ -1,3 +1,5 @@
+/* global defineRule, log */
+
 defineRule('test', {
   whenChanged: 'somedev/bar',
   then: function () {

--- a/wbrules/testrules_runtime_errors.js
+++ b/wbrules/testrules_runtime_errors.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineRule */
 
 defineRule('brokenCellChange', {
   asSoonAs: function () {

--- a/wbrules/testrules_runtime_errors.js
+++ b/wbrules/testrules_runtime_errors.js
@@ -1,4 +1,4 @@
-/* global defineRule */
+/* global defineRule, dev */
 
 defineRule('brokenCellChange', {
   asSoonAs: function () {

--- a/wbrules/testrules_sms_commands.js
+++ b/wbrules/testrules_sms_commands.js
@@ -3,7 +3,7 @@
 var exitCodes = [];
 
 global.__proto__.runShellCommand = function (command, options) {
-  if (exitCodes.length == 0) {
+  if (exitCodes.length === 0) {
     exitCodes = [dev['test_sms/exit_code_2'], dev['test_sms/exit_code_1']];
   }
 

--- a/wbrules/testrules_sms_commands.js
+++ b/wbrules/testrules_sms_commands.js
@@ -1,4 +1,4 @@
-/* global log, Notify */
+/* global defineVirtualDevice, defineRule, log, Notify */
 
 var exitCodes = [];
 

--- a/wbrules/testrules_sms_commands.js
+++ b/wbrules/testrules_sms_commands.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log, Notify */
+/* global defineVirtualDevice, defineRule, dev, log, Notify */
 
 var exitCodes = [];
 

--- a/wbrules/testrules_tg_commands.js
+++ b/wbrules/testrules_tg_commands.js
@@ -1,4 +1,4 @@
-/* global log, Notify */
+/* global defineVirtualDevice, defineRule, log, Notify */
 
 global.__proto__.runShellCommand = function (command, options) {
   log('run command: {}', command);

--- a/wbrules/testrules_tg_commands.js
+++ b/wbrules/testrules_tg_commands.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log, Notify */
+/* global defineVirtualDevice, defineRule, dev, log, Notify */
 
 global.__proto__.runShellCommand = function (command, options) {
   log('run command: {}', command);

--- a/wbrules/testrules_threading_1.js
+++ b/wbrules/testrules_threading_1.js
@@ -1,3 +1,5 @@
+/* global defineRule, defineVirtualDevice, log */
+
 defineVirtualDevice('test', {
   cells: {
     test: {

--- a/wbrules/testrules_threading_2.js
+++ b/wbrules/testrules_threading_2.js
@@ -1,3 +1,5 @@
+/* global defineRule, log */
+
 global.myvar = 84;
 
 function adder(a, b) {

--- a/wbrules/testrules_timers.js
+++ b/wbrules/testrules_timers.js
@@ -1,4 +1,4 @@
-/* global defineRule, startTicker, startTimer, clearTimeout, dev, log */
+/* global defineRule, startTicker, startTimer, clearTimeout, dev, log, timers */
 
 defineRule('startTimer', {
   asSoonAs: function () {

--- a/wbrules/testrules_timers.js
+++ b/wbrules/testrules_timers.js
@@ -1,4 +1,4 @@
-/* global defineRule, startTicker, startTimer, clearTimeout, dev, log, timers */
+/* global defineRule, startTicker, startTimer, dev, log, timers */
 
 defineRule('startTimer', {
   asSoonAs: function () {

--- a/wbrules/testrules_timers.js
+++ b/wbrules/testrules_timers.js
@@ -1,4 +1,4 @@
-/* global defineRule, log */
+/* global defineRule, startTicker, clearTimeout, log */
 
 defineRule('startTimer', {
   asSoonAs: function () {

--- a/wbrules/testrules_timers.js
+++ b/wbrules/testrules_timers.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global defineRule, log */
 
 defineRule('startTimer', {
   asSoonAs: function () {

--- a/wbrules/testrules_timers.js
+++ b/wbrules/testrules_timers.js
@@ -1,4 +1,4 @@
-/* global defineRule, startTicker, clearTimeout, log */
+/* global defineRule, startTicker, startTimer, clearTimeout, dev, log */
 
 defineRule('startTimer', {
   asSoonAs: function () {

--- a/wbrules/testrules_topleveltimers.js
+++ b/wbrules/testrules_topleveltimers.js
@@ -1,4 +1,4 @@
-// -*- mode: js2-mode -*-
+/* global setTimeout, clearTimeout, log */
 
 log('topleveltimers');
 

--- a/wbrules/testrules_topleveltimers.js
+++ b/wbrules/testrules_topleveltimers.js
@@ -1,4 +1,4 @@
-/* global clearTimeout, log */
+/* global log */
 
 log('topleveltimers');
 

--- a/wbrules/testrules_topleveltimers.js
+++ b/wbrules/testrules_topleveltimers.js
@@ -1,4 +1,4 @@
-/* global setTimeout, clearTimeout, log */
+/* global clearTimeout, log */
 
 log('topleveltimers');
 

--- a/wbrules/testrules_track_mqtt.js
+++ b/wbrules/testrules_track_mqtt.js
@@ -1,3 +1,5 @@
+/* global trackMqtt, log */
+
 trackMqtt('/wierd/sub/some', function (obj) {
   log('1. wierd topic got value');
   log('topic: {}, value: {}, retained: {}, qos: {}'.format(obj.topic, obj.value, obj.retained, obj.qos));

--- a/wbrules/testrules_vcells_storage.js
+++ b/wbrules/testrules_vcells_storage.js
@@ -1,4 +1,4 @@
-/* global defineVirtualDevice, defineRule, log */
+/* global defineVirtualDevice, defineRule, dev, log */
 
 defineVirtualDevice('test-vdev', {
   title: 'Test virtual device',

--- a/wbrules/testrules_vcells_storage.js
+++ b/wbrules/testrules_vcells_storage.js
@@ -1,3 +1,5 @@
+/* global defineVirtualDevice, defineRule, log */
+
 defineVirtualDevice('test-vdev', {
   title: 'Test virtual device',
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Resolves #190
```js
var storage = new PersistentStorage("test", {global: true});

storage['a'] = new StorableObject({});
storage.a.c = 10;
storage.a.b = 11;

for (var a in storage.a) {
  log('for in ' + a);
}

Object.keys(storage.a).forEach(function (item) { log('forEach ' + item); })
```

```sh
03-07-2026 15:00:05 for in c
03-07-2026 15:00:05 for in b
03-07-2026 15:00:05 forEach c
03-07-2026 15:00:05 forEach b
03-07-2026 15:00:05 forEach _psself
```

___________________________________
**Что поменялось для пользователей:**
Object.keys() возвращает только пользовательские ключи

___________________________________
**Как проверял/а:**
на вб

