### PR TITLE
Fix disabled cron rules being re-enabled on script reload

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.44.5) stable; urgency=medium
+
+  * Fix disabled cron rules being re-enabled on script reload
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 20 Jul 2026 17:10:00 +0400
+
 wb-rules (2.44.4) stable; urgency=medium
 
   * Update wbgo.so

--- a/wbrules/rule.go
+++ b/wbrules/rule.go
@@ -347,6 +347,9 @@ func (rule *Rule) Check(e *ControlChangeEvent) {
 }
 
 func (rule *Rule) MaybeAddToCron(cron Cron) {
+	if !rule.enabled {
+		return
+	}
 	if cronCond, ok := rule.cond.(*CronRuleCondition); ok {
 		err := cronCond.MaybeAddToCron(cron, func() {
 			if rule.then != nil {

--- a/wbrules/rule_cron_test.go
+++ b/wbrules/rule_cron_test.go
@@ -54,8 +54,65 @@ func (s *RuleCronSuite) TestCron() {
 	)
 }
 
+type RuleCronDisableSuite struct {
+	RuleSuiteBase
+}
+
+func (s *RuleCronDisableSuite) SetupTest() {
+	s.SetupSkippingDefs("testrules_cron_disable.js")
+}
+
+// TestCronRuleStaysDisabledAfterReload is a regression test for a bug where a
+// cron rule turned off via disableRule() came back to life on the next engine
+// reload (e.g. when another script was saved). Refresh() rebuilds the cron from
+// scratch for every rule, and a disabled rule must not be re-armed.
+func (s *RuleCronDisableSuite) TestCronRuleStaysDisabledAfterReload() {
+	s.WaitFor(func() bool {
+		c := make(chan bool)
+		s.engine.CallSync(func() {
+			c <- s.cron != nil && s.cron.started
+		})
+		return <-c
+	})
+
+	// the rule is enabled by default and fires
+	s.cron.invokeEntries("@hourly")
+	s.Verify(
+		"[info] cron rule fired",
+	)
+
+	// disable it via disableRule()
+	s.publish("/devices/cron_switch/controls/enabled/on", "0", "cron_switch/enabled")
+	s.SkipTill("[info] cron rule disabled")
+
+	// disabled rule must not fire
+	s.cron.invokeEntries("@hourly")
+	s.VerifyEmpty()
+
+	// saving another script triggers an engine reload (Refresh -> setupCron),
+	// which rebuilds the cron for all rules; the disabled rule must stay disabled
+	s.Ck("LiveLoadScript()", s.LiveLoadScript("testrules_cron_disable_reload.js"))
+	s.VerifyUnordered(
+		"[info] extra script loaded",
+		"[changed] testrules_cron_disable_reload.js",
+	)
+
+	s.cron.invokeEntries("@hourly")
+	s.VerifyEmpty()
+
+	// re-enabling it via enableRule() brings it back
+	s.publish("/devices/cron_switch/controls/enabled/on", "1", "cron_switch/enabled")
+	s.SkipTill("[info] cron rule enabled")
+
+	s.cron.invokeEntries("@hourly")
+	s.Verify(
+		"[info] cron rule fired",
+	)
+}
+
 func TestRuleCronSuite(t *testing.T) {
 	testutils.RunSuites(t,
 		new(RuleCronSuite),
+		new(RuleCronDisableSuite),
 	)
 }

--- a/wbrules/rule_test.go
+++ b/wbrules/rule_test.go
@@ -21,28 +21,42 @@ const (
 	EXTRA_CTRL_CHANGE_WAIT_TIME_MS = 50
 )
 
+type fakeCronEntry struct {
+	id  cron.EntryID
+	cmd func()
+}
+
 type fakeCron struct {
 	t       *testing.T
 	started bool
-	entries map[string][]func()
+	entries map[string][]fakeCronEntry
 	lastID  cron.EntryID
 }
 
 func newFakeCron(t *testing.T) *fakeCron {
-	return &fakeCron{t, false, make(map[string][]func()), 0}
+	return &fakeCron{t, false, make(map[string][]fakeCronEntry), 0}
 }
 
 func (cron *fakeCron) AddFunc(spec string, cmd func()) (cron.EntryID, error) {
 	cron.lastID++
-	if entries, found := cron.entries[spec]; found {
-		cron.entries[spec] = append(entries, cmd)
-	} else {
-		cron.entries[spec] = []func(){cmd}
-	}
+	cron.entries[spec] = append(cron.entries[spec], fakeCronEntry{cron.lastID, cmd})
 	return cron.lastID, nil
 }
 
 func (cron *fakeCron) Remove(id cron.EntryID) {
+	for spec, entries := range cron.entries {
+		kept := entries[:0]
+		for _, entry := range entries {
+			if entry.id != id {
+				kept = append(kept, entry)
+			}
+		}
+		if len(kept) == 0 {
+			delete(cron.entries, spec)
+		} else {
+			cron.entries[spec] = kept
+		}
+	}
 }
 
 func (cron *fakeCron) Start() {
@@ -62,8 +76,8 @@ func (cron *fakeCron) invokeEntries(spec string) {
 			spec)
 	}
 	if entries, found := cron.entries[spec]; found {
-		for _, cmd := range entries {
-			cmd()
+		for _, entry := range entries {
+			entry.cmd()
 		}
 	}
 }

--- a/wbrules/testrules_cron_disable.js
+++ b/wbrules/testrules_cron_disable.js
@@ -1,0 +1,30 @@
+/* global defineVirtualDevice, defineRule, cron, log, enableRule, disableRule */
+
+defineVirtualDevice('cron_switch', {
+  cells: {
+    enabled: {
+      type: 'switch',
+      value: true,
+    },
+  },
+});
+
+var cronRule = defineRule('cron_disable_test', {
+  when: cron('@hourly'),
+  then: function () {
+    log('cron rule fired');
+  },
+});
+
+defineRule('cron_toggle', {
+  whenChanged: 'cron_switch/enabled',
+  then: function (newValue) {
+    if (newValue) {
+      log('cron rule enabled');
+      enableRule(cronRule);
+    } else {
+      log('cron rule disabled');
+      disableRule(cronRule);
+    }
+  },
+});

--- a/wbrules/testrules_cron_disable_reload.js
+++ b/wbrules/testrules_cron_disable_reload.js
@@ -1,0 +1,3 @@
+/* global log */
+
+log('extra script loaded');


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
После сохранения любого скрипта происходит Refresh -> setupCron -> MaybeAddToCron и так как в MaybeAddToCron не было проверки включено ли правило, то если cron-правило было выключено оно включится само без явного `enableRule`.

___________________________________
**Что поменялось для пользователей:**
выключенное cron-правило не включается само после сохранения другого скрипта

___________________________________
**Как проверял/а:**
на вб с помощью:
```js
defineVirtualDevice("test_cron", {
  cells: {
    enabled: {
      type: "switch",
      value: true
    }
  }
});

var cronRule = defineRule({
  when: cron("* * * * * *"),
  then: function() {
    log.info("test");
  }
});

defineRule({
  whenChanged: "test_cron/enabled",
  then: function(newValue, devName, cellName) {
    if (newValue) {
      log.info("enableRule");
      enableRule(cronRule);
    } else {
      log.info("disableRule");
      disableRule(cronRule);
    }
  }
});
```

