### PR TITLE
Notify: enhance sendTelegramMessage to accept additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,8 +1163,20 @@ var myModule = require("path/to/myModule");
 
 Для отправки SMS используется ModemManager, а если он не установлен, то `gammu`.
 
-`Notify.sendTelegramMessage(token, chatId, text[, callback])` отправляет сообщение
+`Notify.sendTelegramMessage(token, chatId, text[, options][, callback])` отправляет сообщение
 боту с токеном `token`, в чат `chatId` и содержимым (`text`).
+
+Необязательный аргумент `options` — объект с дополнительными параметрами сообщения:
+
+* `parseMode` — режим разбора разметки в тексте сообщения (`parse_mode`),
+  например `"MarkdownV2"` или `"HTML"`;
+* `disableWebPagePreview` — если `true`, отключает предпросмотр ссылок
+  в сообщении (`disable_web_page_preview`);
+* `disableNotification` — если `true`, отправляет сообщение без звукового
+  уведомления (`disable_notification`).
+
+Аргумент `options` можно опустить: если четвёртым аргументом передана функция,
+она воспринимается как `callback`.
 
 Для отправки используется Telegram Bot API метод https://core.telegram.org/bots/api#sendmessage.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.44.5) stable; urgency=medium
+
+  * Notify: enhance sendTelegramMessage to accept additional options
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 20 Jul 2026 11:10:00 +0400
+
 wb-rules (2.44.4) stable; urgency=medium
 
   * Update wbgo.so

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-rules (2.45.0) stable; urgency=medium
 
   * Notify: enhance sendTelegramMessage to accept additional options
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 20 Jul 2026 11:10:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 21 Jul 2026 09:10:00 +0400
 
 wb-rules (2.44.5) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-rules (2.44.5) stable; urgency=medium
+wb-rules (2.45.0) stable; urgency=medium
 
   * Notify: enhance sendTelegramMessage to accept additional options
 

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -331,14 +331,35 @@ exports.sendWebhook = function (opts, callback) {
   });
 };
 
-exports.sendTelegramMessage = function (token, chatId, text, callback) {
+exports.sendTelegramMessage = function (token, chatId, text, options, callback) {
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+
+  } else {
+    options = options || {};
+  }
+
+  var body = "chat_id={}&text={}".format(chatId, encodeURIComponent(text));
+  if (options.parseMode) {
+    body += "&parse_mode={}".format(encodeURIComponent(options.parseMode));
+  }
+
+  if (options.disableWebPagePreview) {
+    body += "&disable_web_page_preview=true";
+  }
+
+  if (options.disableNotification) {
+    body += "&disable_notification=true";
+  }
+
   log('sending telegram message: {}', text);
   runShellCommand(
     "curl -s -X POST https://api.telegram.org/bot{}/sendMessage -H 'Content-Type: application/x-www-form-urlencoded' -d @-".format(token),
     {
       captureErrorOutput: true,
       captureOutput: true,
-      input: 'chat_id={}&text={}'.format(chatId, encodeURIComponent(text)),
+      input: body,
       exitCallback: function exitCallback(exitCode, capturedOutput, capturedErrorOutput) {
         var err = null;
         if (exitCode != 0) {

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -332,30 +332,29 @@ exports.sendWebhook = function (opts, callback) {
 };
 
 exports.sendTelegramMessage = function (token, chatId, text, options, callback) {
-  if (typeof options === "function") {
+  if (typeof options === 'function') {
     callback = options;
     options = {};
-
   } else {
     options = options || {};
   }
 
-  var body = "chat_id={}&text={}".format(chatId, encodeURIComponent(text));
+  var body = 'chat_id={}&text={}'.format(chatId, encodeURIComponent(text));
   if (options.parseMode) {
-    body += "&parse_mode={}".format(encodeURIComponent(options.parseMode));
+    body += '&parse_mode={}'.format(encodeURIComponent(options.parseMode));
   }
 
   if (options.disableWebPagePreview) {
-    body += "&disable_web_page_preview=true";
+    body += '&disable_web_page_preview=true';
   }
 
   if (options.disableNotification) {
-    body += "&disable_notification=true";
+    body += '&disable_notification=true';
   }
 
   log('sending telegram message: {}', text);
   runShellCommand(
-    "curl -s -X POST https://api.telegram.org/bot{}/sendMessage -H 'Content-Type: application/x-www-form-urlencoded' -d @-".format(token),
+    'curl -s -X POST https://api.telegram.org/bot{}/sendMessage -H \'Content-Type: application/x-www-form-urlencoded\' -d @-'.format(token),
     {
       captureErrorOutput: true,
       captureOutput: true,

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -354,7 +354,7 @@ exports.sendTelegramMessage = function (token, chatId, text, options, callback) 
 
   log('sending telegram message: {}', text);
   runShellCommand(
-    'curl -s -X POST https://api.telegram.org/bot{}/sendMessage -H \'Content-Type: application/x-www-form-urlencoded\' -d @-'.format(token),
+    "curl -s -X POST https://api.telegram.org/bot{}/sendMessage -H 'Content-Type: application/x-www-form-urlencoded' -d @-".format(token),
     {
       captureErrorOutput: true,
       captureOutput: true,

--- a/wbrules/rule_notify_tg_test.go
+++ b/wbrules/rule_notify_tg_test.go
@@ -81,6 +81,35 @@ func (s *RuleNotifyTgSuite) TestTgWithQuotes() {
 	)
 }
 
+func (s *RuleNotifyTgSuite) TestTgWithOptions() {
+	s.setErrorCode(0)
+
+	s.publish("/devices/test_tg/controls/send_with_options/on", "1", "test_tg/send_with_options")
+	s.VerifyUnordered(
+		"driver -> /devices/test_tg/controls/send_with_options: [1] (QoS 1)",
+		"tst -> /devices/test_tg/controls/send_with_options/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending telegram message: Test message] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: curl -s -X POST https://api.telegram.org/bot1234567890:abcdefghijklmnopqrstuvwxyz123456789/sendMessage -H 'Content-Type: application/x-www-form-urlencoded' -d @-] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: chat_id=12345678&text=Test%20message&parse_mode=HTML&disable_web_page_preview=true&disable_notification=true] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [telegram send status: ok] (QoS 1)",
+	)
+}
+
+func (s *RuleNotifyTgSuite) TestTgOptionsWithoutCallback() {
+	s.setErrorCode(0)
+
+	// send_options_no_callback passes options but no callback, which must
+	// still be recognized as options rather than mistaken for a callback
+	s.publish("/devices/test_tg/controls/send_options_no_callback/on", "1", "test_tg/send_options_no_callback")
+	s.VerifyUnordered(
+		"driver -> /devices/test_tg/controls/send_options_no_callback: [1] (QoS 1)",
+		"tst -> /devices/test_tg/controls/send_options_no_callback/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending telegram message: Test message] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: curl -s -X POST https://api.telegram.org/bot1234567890:abcdefghijklmnopqrstuvwxyz123456789/sendMessage -H 'Content-Type: application/x-www-form-urlencoded' -d @-] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: chat_id=12345678&text=Test%20message&parse_mode=Markdown] (QoS 1)",
+	)
+}
+
 func TestNotifyTgSuite(t *testing.T) {
 	testutils.RunSuites(t,
 		new(RuleNotifyTgSuite),

--- a/wbrules/testrules_tg_commands.js
+++ b/wbrules/testrules_tg_commands.js
@@ -23,6 +23,12 @@ defineVirtualDevice('test_tg', {
     send_quoted: {
       type: 'pushbutton',
     },
+    send_with_options: {
+      type: 'pushbutton',
+    },
+    send_options_no_callback: {
+      type: 'pushbutton',
+    },
   },
 });
 
@@ -39,5 +45,36 @@ defineRule({
   whenChanged: 'test_tg/send_quoted',
   then: function () {
     Notify.sendTelegramMessage('1234567890:abcdefghijklmnopqrstuvwxyz123456789', '12345678', 'Test "message" \'single\'');
+  },
+});
+
+defineRule({
+  whenChanged: 'test_tg/send_with_options',
+  then: function () {
+    Notify.sendTelegramMessage(
+      '1234567890:abcdefghijklmnopqrstuvwxyz123456789',
+      '12345678',
+      'Test message',
+      {
+        parseMode: 'HTML',
+        disableWebPagePreview: true,
+        disableNotification: true,
+      },
+      function (err) {
+        log('telegram send status: {}', err ? 'error' : 'ok');
+      }
+    );
+  },
+});
+
+defineRule({
+  whenChanged: 'test_tg/send_options_no_callback',
+  then: function () {
+    Notify.sendTelegramMessage(
+      '1234567890:abcdefghijklmnopqrstuvwxyz123456789',
+      '12345678',
+      'Test message',
+      { parseMode: 'Markdown' }
+    );
   },
 });


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Close #212
Ref https://core.telegram.org/bots/api#sendmessage

___________________________________
**Что поменялось для пользователей:**
`sendTelegramMessage` поддерживает дополнитльные опции (parseMode, disableWebPagePreview и disableNotification)

___________________________________
**Как проверял/а:**
на вб

