### PR TITLE
Fix trackMqtt callback not firing on script reload

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-rules (2.45.1) stable; urgency=medium
+
+  * Fix trackMqtt callback not firing on script reload when another script
+    tracks the same topic
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 22 Jul 2026 18:00:00 +0400
+
 wb-rules (2.45.0) stable; urgency=medium
 
   * Notify: enhance sendTelegramMessage to accept additional options

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -2004,6 +2004,14 @@ func mqttTrackerCallbackArgs(msg wbgong.MQTTMessage) objx.Map {
 func (engine *RuleEngine) newTrackHandler(subTopic string) func(wbgong.MQTTMessage) {
 	return func(msg wbgong.MQTTMessage) {
 		engine.mqttTrackerMutex.Lock()
+		// A message may still arrive after the last tracker was removed and the
+		// topic unsubscribed. Ignore it: don't cache (that would resurrect a
+		// stale trackedRetained entry that cleanup will never reclaim) and don't
+		// deliver.
+		if len(engine.tracks[subTopic]) == 0 {
+			engine.mqttTrackerMutex.Unlock()
+			return
+		}
 		// Cache retained values so trackers that join this subscription later
 		// (a second script tracking the same topic, or a reloaded script) can
 		// be replayed the current value; keep already-cached topics up to date

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -2024,14 +2024,21 @@ func (engine *RuleEngine) newTrackHandler(subTopic string) func(wbgong.MQTTMessa
 		// to a retained topic arrives here with Retained=false and is
 		// indistinguishable from a genuinely non-retained publish. The cached
 		// copy is stored as retained, matching how the broker would redeliver it.
-		topicCache := engine.trackedRetained[subTopic]
-		if topicCache == nil {
-			topicCache = make(map[string]wbgong.MQTTMessage)
-			engine.trackedRetained[subTopic] = topicCache
+		//
+		// An empty payload clears a topic's retained value on the broker, so a
+		// fresh subscription would deliver nothing for it: drop it from the cache.
+		if msg.Payload == "" {
+			delete(engine.trackedRetained[subTopic], msg.Topic)
+		} else {
+			topicCache := engine.trackedRetained[subTopic]
+			if topicCache == nil {
+				topicCache = make(map[string]wbgong.MQTTMessage)
+				engine.trackedRetained[subTopic] = topicCache
+			}
+			cachedMsg := msg
+			cachedMsg.Retained = true
+			topicCache[msg.Topic] = cachedMsg
 		}
-		cachedMsg := msg
-		cachedMsg.Retained = true
-		topicCache[msg.Topic] = cachedMsg
 		trackers := make([]MqttTracker, 0, len(engine.tracks[subTopic]))
 		for _, tracker := range engine.tracks[subTopic] {
 			trackers = append(trackers, tracker)

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -667,12 +667,14 @@ type RuleEngine struct {
 	nextTrackID      uint32 // TrackID is used to watch a track in cleanups
 	mqttTrackerMutex sync.Mutex
 
-	// trackedRetained caches the last retained value seen for every actual
-	// topic under each subscription (subscription topic -> actual topic -> msg).
-	// The broker only redelivers retained values when a subscription is first
-	// created, so when a new tracker joins an already-subscribed topic (e.g. a
-	// second script tracking the same topic, or reloading one of them) we replay
-	// the cached values to that tracker to reproduce a fresh subscription.
+	// trackedRetained caches the last value seen for every actual topic under
+	// each subscription (subscription topic -> actual topic -> msg), stored as
+	// retained. The broker only redelivers retained values when a subscription
+	// is first created, so when a new tracker joins an already-subscribed topic
+	// (e.g. a second script tracking the same topic, or reloading one of them)
+	// we replay the cached values to that tracker to reproduce a fresh
+	// subscription. See newTrackHandler for why every message is cached, not
+	// only the ones flagged retained.
 	trackedRetained map[string]map[string]wbgong.MQTTMessage
 
 	cleanupOnStop bool
@@ -2012,17 +2014,24 @@ func (engine *RuleEngine) newTrackHandler(subTopic string) func(wbgong.MQTTMessa
 			engine.mqttTrackerMutex.Unlock()
 			return
 		}
-		// Cache retained values so trackers that join this subscription later
-		// (a second script tracking the same topic, or a reloaded script) can
-		// be replayed the current value, reproducing a fresh subscription.
-		if msg.Retained {
-			topicCache := engine.trackedRetained[subTopic]
-			if topicCache == nil {
-				topicCache = make(map[string]wbgong.MQTTMessage)
-				engine.trackedRetained[subTopic] = topicCache
-			}
-			topicCache[msg.Topic] = msg
+		// Cache the current value of every topic so trackers that join this
+		// subscription later (a second script tracking the same topic, or a
+		// reloaded script) can be replayed it, reproducing a fresh subscription.
+		//
+		// We cache regardless of msg.Retained: the broker clears the retained
+		// flag on messages delivered to an already-subscribed client (it is only
+		// set for values sent because of a new subscription), so a live update
+		// to a retained topic arrives here with Retained=false and is
+		// indistinguishable from a genuinely non-retained publish. The cached
+		// copy is stored as retained, matching how the broker would redeliver it.
+		topicCache := engine.trackedRetained[subTopic]
+		if topicCache == nil {
+			topicCache = make(map[string]wbgong.MQTTMessage)
+			engine.trackedRetained[subTopic] = topicCache
 		}
+		cachedMsg := msg
+		cachedMsg.Retained = true
+		topicCache[msg.Topic] = cachedMsg
 		trackers := make([]MqttTracker, 0, len(engine.tracks[subTopic]))
 		for _, tracker := range engine.tracks[subTopic] {
 			trackers = append(trackers, tracker)

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -2014,17 +2014,14 @@ func (engine *RuleEngine) newTrackHandler(subTopic string) func(wbgong.MQTTMessa
 		}
 		// Cache retained values so trackers that join this subscription later
 		// (a second script tracking the same topic, or a reloaded script) can
-		// be replayed the current value; keep already-cached topics up to date
-		// too, since live updates arrive with the retained flag cleared.
-		topicCache := engine.trackedRetained[subTopic]
-		if _, hadTopic := topicCache[msg.Topic]; msg.Retained || hadTopic {
+		// be replayed the current value, reproducing a fresh subscription.
+		if msg.Retained {
+			topicCache := engine.trackedRetained[subTopic]
 			if topicCache == nil {
 				topicCache = make(map[string]wbgong.MQTTMessage)
 				engine.trackedRetained[subTopic] = topicCache
 			}
-			m := msg
-			m.Retained = true
-			topicCache[msg.Topic] = m
+			topicCache[msg.Topic] = msg
 		}
 		trackers := make([]MqttTracker, 0, len(engine.tracks[subTopic]))
 		for _, tracker := range engine.tracks[subTopic] {

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -667,6 +667,14 @@ type RuleEngine struct {
 	nextTrackID      uint32 // TrackID is used to watch a track in cleanups
 	mqttTrackerMutex sync.Mutex
 
+	// trackedRetained caches the last retained value seen for every actual
+	// topic under each subscription (subscription topic -> actual topic -> msg).
+	// The broker only redelivers retained values when a subscription is first
+	// created, so when a new tracker joins an already-subscribed topic (e.g. a
+	// second script tracking the same topic, or reloading one of them) we replay
+	// the cached values to that tracker to reproduce a fresh subscription.
+	trackedRetained map[string]map[string]wbgong.MQTTMessage
+
 	cleanupOnStop bool
 
 	deviceProxyCache sync.Map
@@ -721,6 +729,7 @@ func NewRuleEngine(driver wbgong.Driver, mqtt wbgong.MQTTClient, options *RuleEn
 		uninitializedRules: make([]*Rule, 0, ENGINE_UNINITIALIZED_RULES_CAPACITY),
 		cleanupOnStop:      options.cleanupOnStop,
 		tracks:             make(map[string]map[uint32]MqttTracker),
+		trackedRetained:    make(map[string]map[string]wbgong.MQTTMessage),
 
 		controlChangeSubs: make([]chan *ControlChangeEvent, 0, ENGINE_CONTROL_CHANGE_SUBS_CAPACITY),
 	}
@@ -1938,11 +1947,36 @@ func (engine *RuleEngine) DefineMqttTracker(topic string, ctx *ESContext) (err e
 
 	tracker := NewMqttTracker(topic, trackerID)
 	tracker.Callback = ctx.WrapCallback(-1)
-	if _, ok := engine.tracks[topic]; !ok {
+
+	_, alreadySubscribed := engine.tracks[topic]
+	if !alreadySubscribed {
 		engine.tracks[topic] = make(MqttTrackerMap)
 		engine.mqttClient.Subscribe(engine.newTrackHandler(topic), topic)
 	}
 	engine.tracks[topic][trackerID] = tracker
+
+	// The broker only redelivers retained values on a fresh subscription.
+	// When this tracker joins a topic that is already subscribed, replay the
+	// cached retained values to it so it behaves like a fresh subscription.
+	// A tracker present before the cache was populated is served by the
+	// subscription's own delivery instead (both happen under the same mutex,
+	// so exactly one of the two paths fires for a given value).
+	if alreadySubscribed {
+		if cached := engine.trackedRetained[topic]; len(cached) > 0 {
+			msgs := make([]wbgong.MQTTMessage, 0, len(cached))
+			for _, msg := range cached {
+				msgs = append(msgs, msg)
+			}
+			callback := tracker.Callback
+			// Deliver asynchronously on the engine loop, mirroring how the
+			// broker delivers retained values after the script finishes loading.
+			go engine.CallSync(func() {
+				for _, msg := range msgs {
+					callback(mqttTrackerCallbackArgs(msg))
+				}
+			})
+		}
+	}
 
 	engine.cleanup.AddCleanup(func() {
 		engine.mqttTrackerMutex.Lock()
@@ -1950,6 +1984,7 @@ func (engine *RuleEngine) DefineMqttTracker(topic string, ctx *ESContext) (err e
 		delete(engine.tracks[topic], trackerID)
 		if len(engine.tracks[topic]) < 1 {
 			delete(engine.tracks, topic)
+			delete(engine.trackedRetained, topic)
 			engine.mqttClient.Unsubscribe(topic)
 		}
 	})
@@ -1957,9 +1992,32 @@ func (engine *RuleEngine) DefineMqttTracker(topic string, ctx *ESContext) (err e
 	return nil
 }
 
+func mqttTrackerCallbackArgs(msg wbgong.MQTTMessage) objx.Map {
+	return objx.New(map[string]any{
+		"topic":    msg.Topic,
+		"value":    msg.Payload,
+		"retained": msg.Retained,
+		"qos":      msg.QoS,
+	})
+}
+
 func (engine *RuleEngine) newTrackHandler(subTopic string) func(wbgong.MQTTMessage) {
 	return func(msg wbgong.MQTTMessage) {
 		engine.mqttTrackerMutex.Lock()
+		// Cache retained values so trackers that join this subscription later
+		// (a second script tracking the same topic, or a reloaded script) can
+		// be replayed the current value; keep already-cached topics up to date
+		// too, since live updates arrive with the retained flag cleared.
+		topicCache := engine.trackedRetained[subTopic]
+		if _, hadTopic := topicCache[msg.Topic]; msg.Retained || hadTopic {
+			if topicCache == nil {
+				topicCache = make(map[string]wbgong.MQTTMessage)
+				engine.trackedRetained[subTopic] = topicCache
+			}
+			m := msg
+			m.Retained = true
+			topicCache[msg.Topic] = m
+		}
 		trackers := make([]MqttTracker, 0, len(engine.tracks[subTopic]))
 		for _, tracker := range engine.tracks[subTopic] {
 			trackers = append(trackers, tracker)
@@ -1968,12 +2026,7 @@ func (engine *RuleEngine) newTrackHandler(subTopic string) func(wbgong.MQTTMessa
 
 		for _, tracker := range trackers {
 			tr := tracker
-			args := objx.New(map[string]any{
-				"topic":    msg.Topic,
-				"value":    msg.Payload,
-				"retained": msg.Retained,
-				"qos":      msg.QoS,
-			})
+			args := mqttTrackerCallbackArgs(msg)
 			engine.CallSync(func() {
 				tr.Callback(args)
 			})

--- a/wbrules/rule_track_mqtt_reload_test.go
+++ b/wbrules/rule_track_mqtt_reload_test.go
@@ -1,0 +1,46 @@
+package wbrules
+
+import (
+	"testing"
+
+	"github.com/wirenboard/wbgong/testutils"
+)
+
+// RuleTrackMqttReloadSuite covers reloading one of several scripts that track
+// the same MQTT topic. Two scripts (dup1, dup2) both call
+// trackMqtt("/wierd/sub/some", ...). The subscription is shared between them,
+// so reloading one script does not tear the subscription down. Previously the
+// reloaded tracker never received the current (retained) value because the
+// broker only redelivers retained values on a fresh subscription. Now the
+// cached retained value is replayed to the reloaded tracker.
+type RuleTrackMqttReloadSuite struct {
+	RuleSuiteBase
+}
+
+func (s *RuleTrackMqttReloadSuite) SetupTest() {
+	s.SetupSkippingDefs("testrules_track_mqtt_dup1.js", "testrules_track_mqtt_dup2.js")
+}
+
+func (s *RuleTrackMqttReloadSuite) TestReloadWithSharedTopic() {
+	// A retained value reaches both trackers.
+	s.publish("/wierd/sub/some", "some-value")
+	s.VerifyUnordered(
+		"tst -> /wierd/sub/some: [some-value] (QoS 1, retained)",
+		"wbrules-log -> /wbrules/log/info: [tmp1: /wierd/sub/some=some-value (retained: true)] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [tmp2: /wierd/sub/some=some-value (retained: true)] (QoS 1)",
+	)
+
+	// Reloading dup1 (dup2 keeps the shared subscription alive) must replay the
+	// cached retained value to the reloaded tracker only. dup2 stays silent.
+	s.ReplaceScript("testrules_track_mqtt_dup1.js", "testrules_track_mqtt_dup1.js")
+	s.VerifyUnordered(
+		"wbrules-log -> /wbrules/updates/changed: [testrules_track_mqtt_dup1.js] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [tmp1: /wierd/sub/some=some-value (retained: true)] (QoS 1)",
+	)
+
+	s.VerifyEmpty()
+}
+
+func TestTrackMqttReload(t *testing.T) {
+	testutils.RunSuites(t, new(RuleTrackMqttReloadSuite))
+}

--- a/wbrules/rule_track_mqtt_reload_test.go
+++ b/wbrules/rule_track_mqtt_reload_test.go
@@ -32,7 +32,7 @@ func (s *RuleTrackMqttReloadSuite) TestReloadWithSharedTopic() {
 
 	// Reloading dup1 (dup2 keeps the shared subscription alive) must replay the
 	// cached retained value to the reloaded tracker only. dup2 stays silent.
-	s.ReplaceScript("testrules_track_mqtt_dup1.js", "testrules_track_mqtt_dup1.js")
+	s.Ck("OverwriteScript()", s.OverwriteScript("testrules_track_mqtt_dup1.js", "testrules_track_mqtt_dup1.js"))
 	s.VerifyUnordered(
 		"wbrules-log -> /wbrules/updates/changed: [testrules_track_mqtt_dup1.js] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [tmp1: /wierd/sub/some=some-value (retained: true)] (QoS 1)",

--- a/wbrules/testrules_track_mqtt_dup1.js
+++ b/wbrules/testrules_track_mqtt_dup1.js
@@ -1,0 +1,5 @@
+/* global trackMqtt, log */
+
+trackMqtt('/wierd/sub/some', function (obj) {
+  log('tmp1: {}={} (retained: {})'.format(obj.topic, obj.value, obj.retained));
+});

--- a/wbrules/testrules_track_mqtt_dup2.js
+++ b/wbrules/testrules_track_mqtt_dup2.js
@@ -1,0 +1,5 @@
+/* global trackMqtt, log */
+
+trackMqtt('/wierd/sub/some', function (obj) {
+  log('tmp2: {}={} (retained: {})'.format(obj.topic, obj.value, obj.retained));
+});


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При подписке на один и тот же топик из разных скриптов по факту под капотом подписываемся в москиту один раз, поэтому retain значение приходило только один раз в первый скрипт. Теперь retain значения для подписаных топиков кешируются и доставляются во все скрипты.

___________________________________
**Что поменялось для пользователей:**
trackMqtt работает предсказуемо

___________________________________
**Как проверял/а:**
на вб

