### PR TITLE
Notify: fix sendSMS()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.45.2) stable; urgency=medium
+
+  * Notify: fix sendSMS()
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 05 Aug 2026 14:00:00 +0400
+
 wb-rules (2.45.1) stable; urgency=medium
 
   * Fix trackMqtt callback not firing on script reload when another script

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -37,7 +37,7 @@ function _sendSMSGammuLike(to, text, command, doneCallback) {
 function _sendSMSModemManager(to, text, doneCallback) {
   log('sending sms (via ModemManager): {}', text);
   var command =
-    'mmcli -m any --messaging-create-sms="number={},text={}" | sed -n \'s#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p\' | xargs mmcli --send -s';
+    'mmcli -m any --messaging-create-sms="number={},text={}" -K | cut -d: -f2- | xargs mmcli --send -s';
 
   if (text.indexOf('"') >= 0) {
     // can't send messages with all types of quotes via mmcli,

--- a/wbrules/rule_notify_sms_test.go
+++ b/wbrules/rule_notify_sms_test.go
@@ -84,7 +84,7 @@ func (s *RuleNotifySmsSuite) TestSmsModemManager() {
 		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager): test value] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test value\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test value\\\"\" -K | cut -d: -f2- | xargs mmcli --send -s] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sms send status: ok] (QoS 1)",
 	)
 }
@@ -100,7 +100,7 @@ func (s *RuleNotifySmsSuite) TestSmsModemManagerWithQuotes() {
 		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager): test \"value\" 'single'] (QoS 1)",
 		"wbrules-log -> /wbrules/log/warning: [ModemManager can't handle SMS with double quotes now, auto replaced with single ones] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test 'value' 'single'\\\"\" | sed -n 's#^Success.*/SMS/\\([0-9]\\+\\).*$#\\1#p' | xargs mmcli --send -s] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test 'value' 'single'\\\"\" -K | cut -d: -f2- | xargs mmcli --send -s] (QoS 1)",
 	)
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
у mmcli поменялся формат вывода, было:
```sh
$ mmcli -m any --messaging-create-sms="number=1234567890,text=test"
Successfully created new SMS: /org/freedesktop/ModemManager1/SMS/51
```
Стало:
```sh
$ mmcli -m any --messaging-create-sms="number=1234567890,text=test"
  ------------------------
  Messaging | created sms: /org/freedesktop/ModemManager1/SMS/62
```
У нового MM появилась опция `-K`:
```sh
Application Options:
  -K, --output-keyvalue                                                                        Run action with machine-friendly key-value output
```
С ней можно избавиться от хрупкого парсинга вывода с sed:
```sh
$ mmcli -m any --messaging-create-sms="number=1234567890,text=test" -K
modem.messaging.created-sms : /org/freedesktop/ModemManager1/SMS/63
$ mmcli -m any --messaging-create-sms="number=1234567890,text=test" -K | cut -d: -f2-
 /org/freedesktop/ModemManager1/SMS/63
```

___________________________________
**Что поменялось для пользователей:**
sendSMS работает

___________________________________
**Как проверял/а:**
на вб

