### PR TITLE
Fix unbounded memory growth with timer-driven rules that write controls

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.46.2) stable; urgency=medium
+
+  * Fix unbounded memory growth with timer-driven rules that write controls
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 10 Aug 2026 12:50:00 +0400
+
 wb-rules (2.46.1) stable; urgency=medium
 
   * Use go 1.26 compiler

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/wirenboard/wb-rules
 
 Package: wb-rules
 Architecture: any
-Depends: libc6 (>= 2.13), ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-rules-system (<< 1.6.13), wb-mqtt-dac (<< 1.1.2)
 Description: Wiren Board Rule Engine
  wb-rules allows you to create control scenarios using JavaScript-based rules.

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 export PATH := /usr/lib/go-1.26/bin:$(PATH)
 
 %:
-	dh $@ --parallel
+	dh $@
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -832,20 +832,26 @@ func (engine *RuleEngine) syncLoop() {
 	}
 }
 
-func (engine *RuleEngine) processEvent(event *ControlChangeEvent) {
-	if wbgong.DebuggingEnabled() {
-		wbgong.Debug.Printf("control change: %s", event.Spec)
-		wbgong.Debug.Printf("rule engine: running rules after control change: %s", event.Spec)
-	}
-	if engine.isDebugControl(event.Spec) {
-		engine.updateDebugEnabled()
+func (engine *RuleEngine) processEvents(events []*ControlChangeEvent) {
+	for _, event := range events {
+		if engine.isDebugControl(event.Spec) {
+			engine.updateDebugEnabled()
+		}
 	}
 
 	engine.CallSync(func() {
-		engine.RunRules(event, NO_TIMER_NAME)
+		for _, event := range events {
+			if wbgong.DebuggingEnabled() {
+				wbgong.Debug.Printf("control change: %s", event.Spec)
+				wbgong.Debug.Printf("rule engine: running rules after control change: %s", event.Spec)
+			}
+			engine.RunRules(event, NO_TIMER_NAME)
+		}
 	})
 
-	engine.notifyControlChangeSubs(event)
+	for _, event := range events {
+		engine.notifyControlChangeSubs(event)
+	}
 }
 
 func (engine *RuleEngine) mainLoop() {
@@ -891,9 +897,7 @@ ReadyWaitLoop:
 
 	// wbgong.Info.Printf("******** READY ********")
 	for range engine.eventBuffer.Observe() {
-		for _, event := range engine.eventBuffer.Retrieve() {
-			engine.processEvent(event)
-		}
+		engine.processEvents(engine.eventBuffer.Retrieve())
 	}
 
 	engine.handleStop()

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -833,10 +833,15 @@ func (engine *RuleEngine) syncLoop() {
 }
 
 func (engine *RuleEngine) processEvents(events []*ControlChangeEvent) {
+	hasDebugControl := false
 	for _, event := range events {
 		if engine.isDebugControl(event.Spec) {
-			engine.updateDebugEnabled()
+			hasDebugControl = true
+			break
 		}
+	}
+	if hasDebugControl {
+		engine.updateDebugEnabled()
 	}
 
 	engine.CallSync(func() {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Изменения контролов передавались движку правил по одному - каждое занимало отдельный слот очереди синхронизации и конкурировало за неё со всеми работающими таймерами, тогда как каждое срабатывание таймера порождало сразу несколько новых изменений. Из-за этого список необработанных событий только рос. Теперь весь пакет изменений обрабатывается за один слот.

___________________________________
**Что поменялось для пользователей:**
события успевают обрабатыватся (при нагрузке в разумных пределах), нет непрерывного роста памяти.

___________________________________
**Как проверял/а:**
на примере правила из оригинального репорта (200 тикеров с периодом 100..2000мс, при каждом срабатывании таймера 3 записи контролов через dev[])

