### PR TITLE
Report wrong-typed control writes to the rule console

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+wb-rules (2.46.4) stable; urgency=medium
+
+  * A control write of a value that cannot be converted to the control's
+    datatype is now reported to the rule debug console (both
+    getControl("dev/ctrl").setValue(...) and dev["dev/ctrl"] = ...); previously
+    it went only to syslog and was invisible in the web UI. The write is still
+    ignored and the rule keeps running, so this is NOT a backward-incompatible
+    change - it just makes the mistake visible. A rejected write also no longer
+    updates the engine's cached value for that control.
+
+ -- Evgeny Boger <boger@wirenboard.com>  Tue, 18 Aug 2026 12:00:00 +0400
+
 wb-rules (2.46.3) stable; urgency=medium
 
   * Reduce CPU usage of control reads and writes: the object returned for

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -115,6 +115,7 @@ type proxyOwner interface {
 	Driver() wbgong.Driver
 	getRev() uint32
 	trackControlSpec(ControlSpec)
+	Log(EngineLogLevel, string)
 }
 
 type DeviceProxy struct {
@@ -432,13 +433,22 @@ func (ctrlProxy *ControlProxy) SetValue(value any, notifySubs bool) error {
 		return ctrl.SetOnValue(value)()
 	})
 
-	if isLocal && notifySubs {
-		// run update value handler immediately, don't wait for wbgong backend
+	if err == nil && isLocal && notifySubs {
+		// run update value handler immediately, don't wait for wbgong backend.
+		// Only on success: a rejected write must not poison the cached value, or
+		// a rule that catches the error and reads the control back would see the
+		// invalid value it just tried (and failed) to write.
 		ctrlProxy.updateValueHandler(nil, value, prevValue, nil)
 	}
 
 	if err != nil {
-		wbgong.Error.Printf("control %s/%s SetValue() error: %s", ctrlProxy.devProxy.name, ctrlProxy.name, err)
+		// A wrong-typed write has been logged-and-ignored since ~2015; keep that
+		// (the rule keeps running - no back-compat break) but surface it where
+		// the user actually looks: the rule debug console. engine.Log publishes
+		// to /wbrules/log/error, which homeui shows; wbgong.Error only reached
+		// syslog. The cache was left untouched above, so reads stay consistent.
+		ctrlProxy.devProxy.owner.Log(ENGINE_LOG_ERROR,
+			fmt.Sprintf("control %s/%s: write ignored (%s)", ctrlProxy.devProxy.name, ctrlProxy.name, err))
 	}
 	return nil
 }

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -1939,7 +1939,10 @@ func (engine *ESEngine) esVdevCellSetValue(ctx *ESContext) int {
 		value = ctx.GetJSObject(0)
 	}
 
-	ctrlProxy.SetValue(value, notifySubs)
+	if err := ctrlProxy.SetValue(value, notifySubs); err != nil {
+		ctx.PushErrorObject(duktape.DUK_ERR_ERROR, err.Error())
+		return duktape.DUK_RET_INSTACK_ERROR
+	}
 
 	return 0
 }
@@ -2084,9 +2087,13 @@ func (engine *ESEngine) initCellObjectPrototype(ctx *ESContext) {
 				return duktape.DUK_RET_TYPE_ERROR
 			}
 
-			errSet := c.SetValue(m[JS_DEVPROXY_FUNC_SETVALUE_ARG], true)
-			if errSet != nil {
-				engine.Log(ENGINE_LOG_ERROR, errSet.Error())
+			// Surface a failed write (e.g. a value that can't be converted to
+			// the control's datatype) as a catchable JS exception so that
+			// `dev["dev/ctrl"] = value` assignments do not fail silently. The
+			// throw propagates out through the lib.js Proxy `set` traps.
+			if errSet := c.SetValue(m[JS_DEVPROXY_FUNC_SETVALUE_ARG], true); errSet != nil {
+				ctx.PushErrorObject(duktape.DUK_ERR_ERROR, errSet.Error())
+				return duktape.DUK_RET_INSTACK_ERROR
 			}
 			return 1
 		},

--- a/wbrules/esengine.go
+++ b/wbrules/esengine.go
@@ -1939,9 +1939,11 @@ func (engine *ESEngine) esVdevCellSetValue(ctx *ESContext) int {
 		value = ctx.GetJSObject(0)
 	}
 
+	// A non-nil error here means the control disappeared (all other write
+	// failures are logged-and-swallowed inside SetValue); report it to the
+	// rule console like any other failed write - a write must never throw.
 	if err := ctrlProxy.SetValue(value, notifySubs); err != nil {
-		ctx.PushErrorObject(duktape.DUK_ERR_ERROR, err.Error())
-		return duktape.DUK_RET_INSTACK_ERROR
+		engine.Log(ENGINE_LOG_ERROR, err.Error())
 	}
 
 	return 0
@@ -2087,13 +2089,9 @@ func (engine *ESEngine) initCellObjectPrototype(ctx *ESContext) {
 				return duktape.DUK_RET_TYPE_ERROR
 			}
 
-			// Surface a failed write (e.g. a value that can't be converted to
-			// the control's datatype) as a catchable JS exception so that
-			// `dev["dev/ctrl"] = value` assignments do not fail silently. The
-			// throw propagates out through the lib.js Proxy `set` traps.
-			if errSet := c.SetValue(m[JS_DEVPROXY_FUNC_SETVALUE_ARG], true); errSet != nil {
-				ctx.PushErrorObject(duktape.DUK_ERR_ERROR, errSet.Error())
-				return duktape.DUK_RET_INSTACK_ERROR
+			errSet := c.SetValue(m[JS_DEVPROXY_FUNC_SETVALUE_ARG], true)
+			if errSet != nil {
+				engine.Log(ENGINE_LOG_ERROR, errSet.Error())
 			}
 			return 1
 		},

--- a/wbrules/rule_setvalue_type_test.go
+++ b/wbrules/rule_setvalue_type_test.go
@@ -1,0 +1,48 @@
+package wbrules
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/wirenboard/wbgong/testutils"
+)
+
+type RuleSetValueTypeSuite struct {
+	RuleSuiteBase
+}
+
+func (s *RuleSetValueTypeSuite) SetupTest() {
+	s.SetupSkippingDefs("testrules_setvalue_type.js")
+}
+
+// A wrong-typed control write is reported to the rule debug console
+// (/wbrules/log/error, which homeui shows) via both getControl(...).setValue()
+// and the dev["dev/ctrl"] = ... proxy, and does NOT throw: the rule keeps
+// running, the cached value is not poisoned, and a correctly-typed write still
+// succeeds.
+func (s *RuleSetValueTypeSuite) TestWrongTypedWriteIsVisibleAndNonFatal() {
+	// The correct write below changes vdev/num, so expect that change too.
+	s.publish("/devices/somedev/controls/sw", "1", "somedev/sw", "vdev/num")
+	s.VerifyUnordered(
+		"tst -> /devices/somedev/controls/sw: [1] (QoS 1, retained)",
+		// both rejected writes are surfaced to the rule log (homeui-visible),
+		// with the control ref and the driver's conversion reason.
+		regexp.MustCompile(
+			`wbrules-log -> /wbrules/log/error: \[control vdev/num: write ignored.*convert.*\] \(QoS 1\)`),
+		regexp.MustCompile(
+			`wbrules-log -> /wbrules/log/error: \[control vdev/num: write ignored.*convert.*\] \(QoS 1\)`),
+		// the rule continued past both bad writes (no throw) and read back the
+		// real value 0 (cache not poisoned).
+		"[info] after bad writes: value=0",
+		// the correctly-typed write succeeded and updated the control.
+		"driver -> /devices/vdev/controls/num: [42] (QoS 1, retained)",
+		"[info] correct write: value=42",
+	)
+	s.VerifyEmpty()
+}
+
+func TestRuleSetValueTypeSuite(t *testing.T) {
+	testutils.RunSuites(t,
+		new(RuleSetValueTypeSuite),
+	)
+}

--- a/wbrules/rule_setvalue_type_test.go
+++ b/wbrules/rule_setvalue_type_test.go
@@ -31,7 +31,10 @@ func (s *RuleSetValueTypeSuite) TestWrongTypedWriteIsVisibleAndNonFatal() {
 			`wbrules-log -> /wbrules/log/error: \[control vdev/num: write ignored.*convert.*\] \(QoS 1\)`),
 		regexp.MustCompile(
 			`wbrules-log -> /wbrules/log/error: \[control vdev/num: write ignored.*convert.*\] \(QoS 1\)`),
-		// the rule continued past both bad writes (no throw) and read back the
+		// a write to a control that does not exist is reported too, not thrown.
+		regexp.MustCompile(
+			`wbrules-log -> /wbrules/log/error: \[.*unexisting control vdev/nonexistent.*\] \(QoS 1\)`),
+		// the rule continued past all bad writes (no throw) and read back the
 		// real value 0 (cache not poisoned).
 		"[info] after bad writes: value=0",
 		// the correctly-typed write succeeded and updated the control.

--- a/wbrules/testrules_setvalue_type.js
+++ b/wbrules/testrules_setvalue_type.js
@@ -23,7 +23,11 @@ defineRule('setValueTypeMismatch', {
     getControl('vdev/num').setValue('not a number'); // via getControl().setValue()
     dev['vdev/num'] = 'also not a number'; // via the dev[...] proxy set trap
 
-    // reached only because neither write threw; value is still the real 0.
+    // A write to a control that does not exist is also reported to the rule
+    // console and ignored, not thrown.
+    dev['vdev/nonexistent'] = 5;
+
+    // reached only because none of the writes threw; value is still the real 0.
     log.info('after bad writes: value=' + dev['vdev/num']);
 
     // A correctly-typed write still succeeds and updates the control.

--- a/wbrules/testrules_setvalue_type.js
+++ b/wbrules/testrules_setvalue_type.js
@@ -1,0 +1,33 @@
+/* global defineVirtualDevice, defineRule, getControl, dev, log */
+
+// A virtual device with a numeric control. Writing a non-numeric value to it is
+// rejected by the driver's value conversion. That rejection must be surfaced to
+// the rule debug console (engine.Log -> /wbrules/log/error, which homeui shows)
+// instead of failing silently to syslog - but it must NOT throw: the rule keeps
+// running (no backward-compat break) and the cached value is not poisoned.
+defineVirtualDevice('vdev', {
+  title: 'VDev',
+  cells: {
+    num: {
+      type: 'value',
+      value: 0,
+    },
+  },
+});
+
+defineRule('setValueTypeMismatch', {
+  whenChanged: 'somedev/sw',
+  then: function () {
+    // Both write paths reject a wrong-typed value: reported to the rule log,
+    // ignored, and execution continues (neither throws).
+    getControl('vdev/num').setValue('not a number'); // via getControl().setValue()
+    dev['vdev/num'] = 'also not a number'; // via the dev[...] proxy set trap
+
+    // reached only because neither write threw; value is still the real 0.
+    log.info('after bad writes: value=' + dev['vdev/num']);
+
+    // A correctly-typed write still succeeds and updates the control.
+    dev['vdev/num'] = 42;
+    log.info('correct write: value=' + dev['vdev/num']);
+  },
+});


### PR DESCRIPTION
## Problem

A control write whose value cannot be converted to the control's datatype was
logged only to syslog. In the web UI it looked as if nothing happened: the
write was silently dropped and there was no error anywhere the user could see.

## Fix

The rejected write is now reported to the rule debug console via
/wbrules/log/error (the same channel homeui shows), for both write paths:
getControl("dev/ctrl").setValue(...) and the dev["dev/ctrl"] = ... proxy
assignment.

The write is still ignored and the rule keeps running, so this is NOT a
backward-incompatible change - it only makes the mistake visible.

In addition, a rejected write no longer updates the engine's cached value for
the control, so reading the control back returns its real value instead of the
value that just failed to write.

Covered by a new test and a 2.46.4 changelog entry.
