### PR TITLE
Fix Notify.sendSMS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-rules (2.46.4) stable; urgency=medium
+
+  * Notify.sendSMS: fix a vulnerability that let the message text or the
+    recipient number run arbitrary commands on the controller; allow double
+    quotes and non-BMP characters in the message
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 14 Aug 2026 12:00:00 +0400
+
 wb-rules (2.46.3) stable; urgency=medium
 
   * Reduce CPU usage of control reads and writes: the object returned for

--- a/debian/control
+++ b/debian/control
@@ -11,5 +11,6 @@ Package: wb-rules
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Breaks: wb-mqtt-confed (<< 1.0.2), wb-rules-system (<< 1.6.13), wb-mqtt-dac (<< 1.1.2)
+Recommends: modemmanager (>=1.22.0), ssmtp, curl
 Description: Wiren Board Rule Engine
  wb-rules allows you to create control scenarios using JavaScript-based rules.

--- a/modules/wb-notify.js
+++ b/modules/wb-notify.js
@@ -37,24 +37,17 @@ function _sendSMSGammuLike(to, text, command, doneCallback) {
 function _sendSMSModemManager(to, text, doneCallback) {
   log('sending sms (via ModemManager): {}', text);
   var command =
-    'mmcli -m any --messaging-create-sms="number={},text={}" -K | cut -d: -f2- | xargs mmcli --send -s';
+    'base64 -d | mmcli -m any --messaging-create-sms="number={}"' +
+    ' --messaging-create-sms-with-text=/dev/stdin -K' +
+    ' | cut -d: -f2- | xargs mmcli --send -s';
 
-  if (text.indexOf('"') >= 0) {
-    // can't send messages with all types of quotes via mmcli,
-    // see https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/275
-    log.warning(
-      "ModemManager can't handle SMS with double quotes now, auto replaced with single ones"
-    );
-    text = text.replace(/"/g, "'");
-  }
-  text = '\\"' + text + '\\"';
-
-  command = command.format(to, text);
+  command = command.format(to);
   debug('sms command: {}'.format(command));
 
   runShellCommand(command, {
     captureErrorOutput: true,
     captureOutput: true,
+    input: _utf8ToBase64(text),
     exitCallback: doneCallback,
   });
 }
@@ -75,6 +68,8 @@ function _checkUse4gModem(doneCallback) {
 function _shellQuote(s) {
   return "'" + String(s).replace(/'/g, "'\\''") + "'";
 }
+
+var _PHONE_NUMBER_RE = /^\+?[0-9]{3,20}$/;
 
 function _isValidJSON(str) {
   try {
@@ -250,6 +245,14 @@ exports.sendSMS = function (to, text, command, callback) {
   if (typeof command === 'function') {
     callback = command;
     command = undefined;
+  }
+
+  if (!_PHONE_NUMBER_RE.test(to)) {
+    _notifyDone(
+      callback,
+      new Error("error sending sms: invalid recipient '" + to + "', expected a phone number")
+    );
+    return;
   }
 
   var doneCallback = function (exitCode, capturedOutput, capturedErrorOutput) {

--- a/wbrules/rule_notify_sms_test.go
+++ b/wbrules/rule_notify_sms_test.go
@@ -74,6 +74,9 @@ func (s *RuleNotifySmsSuite) TestSmsErrorWithoutCallback() {
 	)
 }
 
+const mmcliCommand = `base64 -d | mmcli -m any --messaging-create-sms="number=88005553535"` +
+	` --messaging-create-sms-with-text=/dev/stdin -K | cut -d: -f2- | xargs mmcli --send -s`
+
 func (s *RuleNotifySmsSuite) TestSmsModemManager() {
 	s.setErrorCode(1, 0) // to make mmcli check OK
 	s.setErrorCode(2, 0) // to make mmcli call happy
@@ -84,7 +87,8 @@ func (s *RuleNotifySmsSuite) TestSmsModemManager() {
 		"tst -> /devices/test_sms/controls/send/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager): test value] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test value\\\"\" -K | cut -d: -f2- | xargs mmcli --send -s] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: "+mmcliCommand+"] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: dGVzdCB2YWx1ZQ==] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sms send status: ok] (QoS 1)",
 	)
 }
@@ -99,9 +103,47 @@ func (s *RuleNotifySmsSuite) TestSmsModemManagerWithQuotes() {
 		"tst -> /devices/test_sms/controls/send_quoted/on: [1] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
 		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager): test \"value\" 'single'] (QoS 1)",
-		"wbrules-log -> /wbrules/log/warning: [ModemManager can't handle SMS with double quotes now, auto replaced with single ones] (QoS 1)",
-		"wbrules-log -> /wbrules/log/info: [run command: mmcli -m any --messaging-create-sms=\"number=88005553535,text=\\\"test 'value' 'single'\\\"\" -K | cut -d: -f2- | xargs mmcli --send -s] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: "+mmcliCommand+"] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: dGVzdCAidmFsdWUiICdzaW5nbGUn] (QoS 1)",
 	)
+}
+
+func (s *RuleNotifySmsSuite) TestSmsModemManagerTextInjection() {
+	s.setErrorCode(1, 0) // to make mmcli check OK
+	s.setErrorCode(2, 0) // to make mmcli call happy
+
+	s.publish("/devices/test_sms/controls/send_injection/on", "1", "test_sms/send_injection")
+	s.VerifyUnordered(
+		"driver -> /devices/test_sms/controls/send_injection: [1] (QoS 1)",
+		"tst -> /devices/test_sms/controls/send_injection/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: wb-gsm should_enable] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sending sms (via ModemManager): value $(id)] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [run command: "+mmcliCommand+"] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [input: dmFsdWUgJChpZCk=] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sms send status: ok] (QoS 1)",
+	)
+}
+
+func (s *RuleNotifySmsSuite) TestSmsModemManagerNonBMP() {
+	s.setErrorCode(1, 0) // to make mmcli check OK
+	s.setErrorCode(2, 0) // to make mmcli call happy
+
+	s.publish("/devices/test_sms/controls/send_nonbmp/on", "1", "test_sms/send_nonbmp")
+	s.SkipTill("wbrules-log -> /wbrules/log/info: [run command: " + mmcliCommand + "] (QoS 1)")
+	s.Verify(
+		"wbrules-log -> /wbrules/log/info: [input: 8J+PoCDRgtC10LrRgdGC] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sms send status: ok] (QoS 1)",
+	)
+}
+
+func (s *RuleNotifySmsSuite) TestSmsInvalidRecipient() {
+	s.publish("/devices/test_sms/controls/send_bad_number/on", "1", "test_sms/send_bad_number")
+	s.VerifyUnordered(
+		"driver -> /devices/test_sms/controls/send_bad_number: [1] (QoS 1)",
+		"tst -> /devices/test_sms/controls/send_bad_number/on: [1] (QoS 1)",
+		"wbrules-log -> /wbrules/log/info: [sms send status: error] (QoS 1)",
+	)
+	s.VerifyEmpty()
 }
 
 func TestNotifySmsSuite(t *testing.T) {

--- a/wbrules/testrules_sms_commands.js
+++ b/wbrules/testrules_sms_commands.js
@@ -34,6 +34,15 @@ defineVirtualDevice('test_sms', {
     send_quoted: {
       type: 'pushbutton',
     },
+    send_injection: {
+      type: 'pushbutton',
+    },
+    send_bad_number: {
+      type: 'pushbutton',
+    },
+    send_nonbmp: {
+      type: 'pushbutton',
+    },
   },
 });
 
@@ -49,8 +58,33 @@ defineRule({
 defineRule({
   whenChanged: 'test_sms/send_quoted',
   then: function () {
-    // can't send messages with all types of quotes via mmcli,
-    // see https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/275
     Notify.sendSMS('88005553535', 'test "value" \'single\'');
+  },
+});
+
+defineRule({
+  whenChanged: 'test_sms/send_injection',
+  then: function () {
+    Notify.sendSMS('88005553535', 'value $(id)', function (err) {
+      log('sms send status: {}', err ? 'error' : 'ok');
+    });
+  },
+});
+
+defineRule({
+  whenChanged: 'test_sms/send_bad_number',
+  then: function () {
+    Notify.sendSMS('$(id)', 'test value', function (err) {
+      log('sms send status: {}', err ? 'error' : 'ok');
+    });
+  },
+});
+
+defineRule({
+  whenChanged: 'test_sms/send_nonbmp',
+  then: function () {
+    Notify.sendSMS('88005553535', '🏠 текст', function (err) {
+      log('sms send status: {}', err ? 'error' : 'ok');
+    });
   },
 });


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* поправлена уязвимость позволяющая инжектить шел комманды в тексте сообщения => передаем текст сообщения через stdin в base64
* за счет передачи в base64 автоматом чинится отправка емодзи в тексте
* также автоматом теперь можно в том числе двойные кавычки в тексте отправлять (раньше заменялись на одинарные)
* номер получателя теперь проверяется на валидность
* добавлены зависимости необходимые для нотификаций

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
```js
Notify.sendSMS("+7**********", 'тест $(id) "koira" \'fuh\' 🏠')
```
<img width="439" height="387" alt="Screen Shot 2026-08-17 at 17 19 39" src="https://github.com/user-attachments/assets/40a1e8f8-2601-4b58-a8e2-0fcb74051e77" />
