### PR TITLE
Fix flaky tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.46.6) stable; urgency=medium
+
+  * Fix flaky tests, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 04 Sep 2026 18:00:00 +0400
+
 wb-rules (2.46.5) stable; urgency=medium
 
   * Notify.sendSMS: fix a vulnerability that let the message text or the

--- a/wbrules/rule_test.go
+++ b/wbrules/rule_test.go
@@ -402,30 +402,55 @@ func (s *RuleSuiteBase) SetCellValueNoVerify(devID, ctrlID string, value any) {
 }
 
 func (s *RuleSuiteBase) TearDownTest() {
+	// Register cleanup before checking the broker: VerifyEmpty uses FailNow,
+	// so cleanup must not depend on it returning normally.
+	defer func() {
+		if s.driver != nil {
+			s.driver.Close()
+		}
+	}()
+	defer func() {
+		if s.logClient != nil {
+			s.logClient.Stop()
+		}
+	}()
+	defer func() {
+		if s.client != nil {
+			s.client.Stop()
+		}
+	}()
+	defer func() {
+		if s.driver != nil {
+			s.Ck("StopLoop()", s.driver.StopLoop())
+		}
+	}()
+	defer func() {
+		if s.CleanUp != nil {
+			s.CleanUp()
+		}
+	}()
+	defer func() {
+		if s.engine != nil {
+			s.engine.ClosePersistentDB()
+		}
+		s.PersistentDBFile = ""
+		s.VdevStorageFile = ""
+	}()
+	defer func() {
+		if s.engine != nil {
+			s.engine.Stop()
+			s.WaitFor(func() bool {
+				return !s.engine.IsActive()
+			})
+		}
+	}()
+	defer func() {
+		if s.DataFileFixture != nil {
+			s.TearDownDataFiles()
+		}
+	}()
+
 	s.Broker.VerifyEmpty()
-
-	s.TearDownDataFiles()
-
-	s.engine.Stop()
-	s.WaitFor(func() bool {
-		return !s.engine.IsActive()
-	})
-
-	s.engine.ClosePersistentDB()
-	s.PersistentDBFile = ""
-	s.VdevStorageFile = ""
-
-	if s.CleanUp != nil {
-		s.CleanUp()
-	}
-
-	err := s.driver.StopLoop()
-	s.Ck("StopLoop()", err)
-
-	s.client.Stop()
-	s.logClient.Stop()
-
-	s.driver.Close()
 }
 
 // TBD: metadata (like, meta["devname"]["controlName"])


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Иногда эти 2 теста не проходят:
```sh
        github.com/stretchr/testify/require.Fail({0x1202a70, 0x31a091b28908}, {0x11bacba, 0x13}, {0x31a091877bc0, 0x2, 0x2})
            github.com/stretchr/testify@v1.11.1/require/require.go:522 +0xca
        github.com/stretchr/testify/require.(*Assertions).Fail(0x31a0917cb900, {0x11bacba, 0x13}, {0x31a091877bc0, 0x2, 0x2})
         github.com/stretchr/testify@v1.11.1/require/require_forward.go:423 +0x9d
        github.com/wirenboard/wbgong/testutils.(*Suite).Ck(0x7fffa5eef438?, {0x11bacba, 0x13}, {0x1200d20, 0x31a0909a9060})
           github.com/wirenboard/wbgong@v0.7.4/testutils/testutils.go:421 +0xae
        github.com/wirenboard/wb-rules/wbrules.(*RuleSuiteBase).SetupTest(0x31a090ccb600, 0x0, {0x31a090973db0, 0x1, 0x1})
                github.com/wirenboard/wb-rules/wbrules/rule_test.go:257 +0x2aa
        github.com/wirenboard/wb-rules/wbrules.(*RuleSuiteBase).SetupSkippingDefs(0x31a090ccb600, {0x31a091e12db0?, 0x11a12c0?, 0x11b7d9d?})
            github.com/wirenboard/wb-rules/wbrules/rule_test.go:343 +0x2c
        github.com/wirenboard/wb-rules/wbrules.(*VirtualCellsStorageSuite).SetupTest(0x31a090ccb600)
             github.com/wirenboard/wb-rules/wbrules/vcells_storage_test.go:31 +0x91
        github.com/stretchr/testify/suite.Run.func1(0x31a091b28908)
             github.com/stretchr/testify@v1.11.1/suite/suite.go:188 +0x210
        testing.tRunner(0x31a091b28908, 0x31a09168a5a0)
          testing/testing.go:2036 +0xea
        created by testing.(*T).Run in goroutine 745
             testing/testing.go:2101 +0x4c5
--- FAIL: TestVirtualCellsStorageSuite (1.04s)
    --- FAIL: TestVirtualCellsStorageSuite/TestStorage1 (0.02s)
    --- FAIL: TestVirtualCellsStorageSuite/TestStorage2 (1.01s)
FAIL
coverage: 72.1% of statements
FAIL   github.com/wirenboard/wb-rules/wbrules  50.307s
FAIL
```
Что происходит: скорее всего в процессе TearDown пофейлился Broker.VerifyEmpty (ждет 50мс), после этого driver остался не остановлен, следующий тест не смог создать новый driver, так как предыдущий держит лок на test-vcells.db

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


